### PR TITLE
Fixed bug - not included std::string

### DIFF
--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -30,6 +30,7 @@
 #ifndef TINS_EXCEPTIONS_H
 #define TINS_EXCEPTIONS_H
 
+#include <string>
 #include <stdexcept>
 
 namespace Tins {


### PR DESCRIPTION
Error details:
implicit instantiation of undefined template std::basic_string

Occurred when compiling libtins on Mac OS X 10.9.1
