### PR TITLE
Allow Sniffer to enable monitor mode on interface

### DIFF
--- a/examples/beacon_display.cpp
+++ b/examples/beacon_display.cpp
@@ -47,7 +47,7 @@ private:
 };
  
 void BeaconSniffer::run(const std::string &iface) {
-    Sniffer sniffer(iface, 1500, true, "type mgt subtype beacon");
+    Sniffer sniffer(iface, 1500, true, "type mgt subtype beacon", true);
     sniffer.sniff_loop(make_sniffer_handler(this, &BeaconSniffer::callback));
 }
  

--- a/include/sniffer.h
+++ b/include/sniffer.h
@@ -254,29 +254,35 @@ namespace Tins {
 
         /**
          * Constructs an instance of Sniffer.
+         *
+         * By default the interface won't be put into promiscuous mode, and won't
+         * be put into monitor mode.
+         *
          * \param device The device which will be sniffed.
          * \param max_packet_size The maximum packet size to be read.
          * \param promisc bool indicating wether to put the interface in promiscuous mode.(optional)
          * \param filter A capture filter to be used on the sniffing session.(optional);
+         * \param rfmon Indicates if the interface should be put in monitor mode.(optional);
          */
         Sniffer(const std::string &device, unsigned max_packet_size,
-          bool promisc = false, const std::string &filter = "");
+          bool promisc = false, const std::string &filter = "", bool rfmon = false);
 
         /**
          * \brief Constructs an instance of Sniffer.
          *
          * The maximum capture size is set to 65535. By default the interface won't
-         * be put into promiscuous mode.
+         * be put into promiscuous mode, and won't be put into monitor mode.
          * 
          * \param device The device which will be sniffed.
          * \param promisc Indicates if the interface should be put in promiscuous mode.
          * \param filter A capture filter to be used on the sniffing session.(optional);
+         * \param rfmon Indicates if the interface should be put in monitor mode.(optional);
          */
         Sniffer(const std::string &device, promisc_type promisc = NON_PROMISC, 
-          const std::string &filter = "");
+          const std::string &filter = "", bool rfmon = false);
     private:
         void init_sniffer(const std::string &device, unsigned max_packet_size,
-          bool promisc = false, const std::string &filter = "");
+          bool promisc = false, const std::string &filter = "", bool rfmon = false);
     };
     
     /**


### PR DESCRIPTION
Closes #7

I added this by creating a sort of "shim" for pcap that's in the sniffer.cpp as `pcap_open_live_extended()`. I can also put it directly in the `init_sniffer()` or somewhere else if preferred.
