### PR TITLE
changed ICMP::check to ICMP::checksum

### DIFF
--- a/include/icmp.h
+++ b/include/icmp.h
@@ -258,7 +258,7 @@ namespace Tins {
          *
          * \return Returns the checksum as an unit16_t.
          */
-        uint16_t check() const { return Endian::be_to_host(_icmp.check); }
+        uint16_t checksum() const { return Endian::be_to_host(_icmp.check); }
 
         /**
          * \brief Getter for the echo id.
@@ -377,7 +377,7 @@ namespace Tins {
             } un;
         } TINS_END_PACK;
 
-        void check(uint16_t new_check);
+        void checksum(uint16_t new_check);
         
         /** \brief Serialices this ICMP PDU.
          * \param buffer The buffer in which the PDU will be serialized.

--- a/src/icmp.cpp
+++ b/src/icmp.cpp
@@ -86,7 +86,7 @@ void ICMP::type(Flags new_type) {
     _icmp.type = new_type;
 }
 
-void ICMP::check(uint16_t new_check) {
+void ICMP::checksum(uint16_t new_check) {
     _icmp.check = Endian::host_to_be(new_check);
 }
 


### PR DESCRIPTION
just noticed that the getter is public, which means this changes the api... but now i can get libtins working with osx + xcode! i'm psyched.
