### PR TITLE
minimum automake version from 1.13 -> 1.11

### DIFF
--- a/configure
+++ b/configure
@@ -2506,7 +2506,7 @@ test -n "$target_alias" &&
 
 ac_config_headers="$ac_config_headers include/config.h"
 
-am__api_version='1.13'
+am__api_version='1.11'
 
 # Find a good install program.  We prefer a C program (faster),
 # so one script is as good as another.  But avoid the broken or


### PR DESCRIPTION
By lowering the automake version, you can compile libtins on the default debian install for the beaglebone black. I only tested that this works for the beacon frame example on the beaglebone (debian 3.15 armv7) and macbook osx 10.9 (darwin 13.3.0 x86_64).
