### PR TITLE
fix armv5 alignment issues

### DIFF
--- a/include/dhcpv6.h
+++ b/include/dhcpv6.h
@@ -30,6 +30,7 @@
 #ifndef TINS_DHCPV6_H
 #define TINS_DHCPV6_H
 
+#include <cstring>
 #include <list>
 #include "pdu.h"
 #include "endianness.h"
@@ -886,9 +887,11 @@ void class_option_data2option(InputIterator start, InputIterator end,
   std::vector<uint8_t>& buffer, size_t start_index = 0) 
 {
     size_t index = start_index;
+    uint16_t uint16_t_buffer;
     while(start != end) {
         buffer.resize(buffer.size() + sizeof(uint16_t) + start->size());
-        *(uint16_t*)&buffer[index] = Endian::host_to_be<uint16_t>(start->size());
+        uint16_t_buffer = Endian::host_to_be<uint16_t>(start->size());
+        std::memcpy(&buffer[index], &uint16_t_buffer, sizeof(uint16_t));
         index += sizeof(uint16_t);
         std::copy(start->begin(), start->end(), buffer.begin() + index);
         index += start->size();
@@ -904,9 +907,9 @@ OutputType option2class_option_data(const uint8_t *ptr, uint32_t total_sz)
     OutputType output;
     size_t index = 0;
     while(index + 2 < total_sz) {
-        uint16_t size = Endian::be_to_host(
-            *(const uint16_t*)(ptr + index)
-        );
+        uint16_t size;
+        std::memcpy(&size, ptr + index, sizeof(uint16_t));
+        size = Endian::be_to_host(size);
         index += sizeof(uint16_t);
         if(index + size > total_sz)
             throw option_not_found();

--- a/include/pdu_option.h
+++ b/include/pdu_option.h
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <iterator>
+#include <cstring>
 #include <algorithm>
 #include <string>
 #include <stdint.h>
@@ -266,8 +267,8 @@ namespace Internals {
             if(opt.data_size() != sizeof(T) + sizeof(U))
                 throw malformed_option();
             std::pair<T, U> output;
-            output.first = *(const T*)opt.data_ptr();
-            output.second = *(const U*)(opt.data_ptr() + sizeof(T));
+            std::memcpy(&output.first, opt.data_ptr(), sizeof(T));
+            std::memcpy(&output.second, opt.data_ptr() + sizeof(T), sizeof(U));
             if(PDUType::endianness == PDUType::BE) {
                 output.first = Endian::be_to_host(output.first);
                 output.second = Endian::be_to_host(output.second);

--- a/src/dhcp.cpp
+++ b/src/dhcp.cpp
@@ -29,6 +29,7 @@
 
 #include <stdexcept>
 #include <cassert>
+#include <cstring>
 #include "endianness.h"
 #include "dhcp.h"
 #include "ethernetII.h"
@@ -52,7 +53,9 @@ DHCP::DHCP(const uint8_t *buffer, uint32_t total_sz)
     buffer += BootP::header_size() - vend().size();
     total_sz -= BootP::header_size() - vend().size();
     uint8_t args[2] = {0};
-    if(total_sz < sizeof(uint32_t) || *(uint32_t*)buffer != Endian::host_to_be<uint32_t>(0x63825363))
+    uint32_t uint32_t_buffer;
+    std::memcpy(&uint32_t_buffer, buffer, sizeof(uint32_t));
+    if(total_sz < sizeof(uint32_t) || uint32_t_buffer != Endian::host_to_be<uint32_t>(0x63825363))
         throw malformed_packet();
     buffer += sizeof(uint32_t);
     total_sz -= sizeof(uint32_t);

--- a/src/dot11/dot11_data.cpp
+++ b/src/dot11/dot11_data.cpp
@@ -153,7 +153,7 @@ Dot11QoSData::Dot11QoSData(const uint8_t *buffer, uint32_t total_sz)
     total_sz -= sz;
     if(total_sz < sizeof(_qos_control))
         throw malformed_packet();
-    _qos_control = *(uint16_t*)buffer;
+    std::memcpy(&_qos_control, buffer, sizeof(uint16_t));
     total_sz -= sizeof(uint16_t);
     buffer += sizeof(uint16_t);
     if(total_sz) {
@@ -178,7 +178,7 @@ uint32_t Dot11QoSData::write_fixed_parameters(uint8_t *buffer, uint32_t total_sz
     #ifdef TINS_DEBUG
     assert(sz <= total_sz);
     #endif
-    *(uint16_t*)buffer = this->_qos_control;
+    std::memcpy(buffer, &this->_qos_control, sizeof(uint16_t));
     return sz;
 }
 } // namespace Tins

--- a/src/dot11/dot11_mgmt.cpp
+++ b/src/dot11/dot11_mgmt.cpp
@@ -496,7 +496,7 @@ Dot11ManagementFrame::fh_params_set Dot11ManagementFrame::fh_params_set::from_op
     if(opt.data_size() != 5)
         throw malformed_option();
     fh_params_set output;
-    output.dwell_time = Endian::le_to_host(*(uint16_t*)opt.data_ptr());
+    std::memcpy(&output.dwell_time, opt.data_ptr(), sizeof(uint16_t));
     output.hop_set = opt.data_ptr()[2];
     output.hop_pattern = opt.data_ptr()[3];
     output.hop_index = opt.data_ptr()[4];
@@ -510,8 +510,8 @@ Dot11ManagementFrame::cf_params_set Dot11ManagementFrame::cf_params_set::from_op
     cf_params_set output;
     output.cfp_count = *opt.data_ptr();
     output.cfp_period = opt.data_ptr()[1];
-    output.cfp_max_duration = Endian::le_to_host(*(uint16_t*)&opt.data_ptr()[2]);
-    output.cfp_dur_remaining = Endian::le_to_host(*(uint16_t*)&opt.data_ptr()[4]);
+    std::memcpy(&output.cfp_max_duration, &opt.data_ptr()[2], sizeof(uint16_t));
+    std::memcpy(&output.cfp_dur_remaining, &opt.data_ptr()[4], sizeof(uint16_t));
     return output;
 }
 
@@ -601,9 +601,10 @@ Dot11ManagementFrame::bss_load_type Dot11ManagementFrame::bss_load_type::from_op
     bss_load_type output;
     
     const uint8_t *ptr = opt.data_ptr();
-    output.station_count = Endian::le_to_host(*(uint16_t*)ptr);
+    std::memcpy(&output.station_count, ptr, sizeof(uint16_t));
     output.channel_utilization = ptr[2];
-    output.available_capacity = Endian::le_to_host(*(uint16_t*)(ptr + 3));
+    std::memcpy(&output.available_capacity, ptr + 3, sizeof(uint16_t));
+    output.available_capacity = Endian::le_to_host(output.available_capacity);
     return output;
 }
 

--- a/src/radiotap.cpp
+++ b/src/radiotap.cpp
@@ -382,9 +382,10 @@ void RadioTap::write_serialization(uint8_t *buffer, uint32_t total_sz, const PDU
         buffer += sizeof(_max_power);
     }
     if((_flags & 0x10) != 0 && inner_pdu()) {
-        *(uint32_t*)(buffer + inner_pdu()->size()) = Endian::host_to_le(
+    	uint32_t crc32 = Endian::host_to_le(
             Utils::crc32(buffer, inner_pdu()->size())
         );
+        memcpy(buffer + inner_pdu()->size(), &crc32, sizeof(uint32_t));
     }
 }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -218,13 +218,22 @@ std::string to_string(PDU::PDUType pduType) {
 
 uint32_t do_checksum(const uint8_t *start, const uint8_t *end) {
     uint32_t checksum(0);
-    uint16_t *ptr = (uint16_t*)start, *last = (uint16_t*)end, padding(0);
+    const uint8_t *last = end;
+    uint16_t buffer = 0;
+    uint16_t padding = 0;
+    const uint8_t *ptr = start;
+
     if(((end - start) & 1) == 1) {
-        last = (uint16_t*)end - 1;
+        last = end - 1;
         padding = *(end - 1) << 8;
     }
-    while(ptr < last)
-        checksum += Endian::host_to_be(*(ptr++));
+
+    while(ptr < last) {
+        memcpy(&buffer, ptr, sizeof(uint16_t));
+        checksum += Endian::host_to_be(buffer);
+        ptr += sizeof(uint16_t);
+    }
+
     return checksum + padding;
 }
 


### PR DESCRIPTION
ARMv4 and ARMv5 don't provide unaligned memory access as you can read here: http://stackoverflow.com/questions/14032434/casting-pointers-on-embedded-devices/14035351#14035351

We tried to use libtins on an ARMv5 platform and stumbled across this issue.
I tried to replace all occurences of possibly unaligned access with the use of `std::memcpy`.

I hope I found all places but I am not 100% sure.
At least, the tests are now all successful on our platform.

There are some places were I had to add a temporary variable that I simply named `uint16_t_buffer` or `uint32_t_buffer`. These are for sure not the best names for these but I didn't dig too deep into the codebase to come up with better names. So, you may want to change them. ;-)
