### PR TITLE
Fixed big endian version for flags_type

### DIFF
--- a/include/tins/radiotap.h
+++ b/include/tins/radiotap.h
@@ -390,17 +390,17 @@ namespace Tins {
                     tsft:1,
                     reserved3:1,
                     rx_flags:1,
-                    db_tx_attenuation:1,
-                    dbm_tx_power:1,
-                    antenna:1,
-                    db_signal:1,
                     db_noise:1,
+                    db_signal:1,
+                    antenna:1,
+                    dbm_tx_power:1,
+                    db_tx_attenuation:1,
                     tx_attenuation:1,
                     reserved2:5,
                     channel_plus:1,
                     reserved1:2,
-                    reserved4:7,
-                    ext:1;
+                    ext:1,
+                    reserved4:7;
             } TINS_END_PACK;
         #endif
 


### PR DESCRIPTION
Byte 1 and 3 in the big endian version of flags_type seems to be mixed up.
Unfortunately I can't test it.

bit number | litte endian | big endian                                          
--------------|----------------|--------------                                          
0 | tsft:1, | lock_quality:1,                                                    
1 | flags:1, | dbm_noise:1,                                                     
2 | rate:1, | dbm_signal:1,                                                     
3 | channel:1, | fhss:1,                                                        
4 | fhss:1, | channel:1,                                                        
5 | dbm_signal:1, | rate:1,                                                     
6 | dbm_noise:1, | flags:1,                                                     
7 | lock_quality:1, | tsft:1,                                                   
 | |                                                                            
8 | tx_attenuation:1, | reserved3:1,                                            
9 | db_tx_attenuation:1, | rx_flags:1,                                          
10 | dbm_tx_power:1, | db_tx_attenuation:1,                                     
11 | antenna:1, | dbm_tx_power:1,                                               
12 | db_signal:1, | antenna:1,                                                  
13 | db_noise:1, | db_signal:1,                                                 
14 | rx_flags:1, | db_noise:1,                                                  
15 | reserved1:3, | tx_attenuation:1,                                           
 | |                                                                            
16 | | reserved2:5,                                                             
17 | |                                                                          
18 | channel_plus:1, |                                                          
19 | reserved2:12, |                                                            
20 | |                                                                          
21 | | channel_plus:1,                                                          
22 | | reserved1:2,                                                             
23 | |                                                                          
 | |                                                                        
24 | | reserved4:7,                                                             
25 | |                                                                          
26 | |                                                                          
27 | |                                                                          
28 | |                                                                          
29 | |                                                                          
30 | |                                                                          
31 | ext:1; | ext:1; 