### PR TITLE
Fixed radiotap parsing #55

### DIFF
--- a/include/tins/radiotap.h
+++ b/include/tins/radiotap.h
@@ -366,6 +366,7 @@ namespace Tins {
                     dbm_signal:1,
                     dbm_noise:1,
                     lock_quality:1,
+
                     tx_attenuation:1,
                     db_tx_attenuation:1,
                     dbm_tx_power:1,
@@ -373,9 +374,13 @@ namespace Tins {
                     db_signal:1,
                     db_noise:1,
                     rx_flags:1,
-                    reserved1:3,
+                    reserved3:1,
+
+                    reserved1:2,
                     channel_plus:1,
-                    reserved2:12,
+                    reserved2:5,
+
+                    reserved4:7,
                     ext:1;
             } TINS_END_PACK;
         #else
@@ -388,6 +393,7 @@ namespace Tins {
                     rate:1,
                     flags:1,
                     tsft:1,
+
                     reserved3:1,
                     rx_flags:1,
                     db_tx_attenuation:1,
@@ -396,11 +402,13 @@ namespace Tins {
                     db_signal:1,
                     db_noise:1,
                     tx_attenuation:1,
+
                     reserved2:5,
                     channel_plus:1,
                     reserved1:2,
-                    reserved4:7,
-                    ext:1;
+
+                    ext:1,
+                    reserved4:7;
             } TINS_END_PACK;
         #endif
 

--- a/src/radiotap.cpp
+++ b/src/radiotap.cpp
@@ -94,9 +94,12 @@ RadioTap::RadioTap(const uint8_t *buffer, uint32_t total_sz)
     // Also skip the header
     buffer += sizeof(_radio);
     radiotap_hdr_size -= sizeof(_radio);
-    // Align start of contents to 8 bytes boundary
-    buffer += (buffer - buffer_start) % 8;
-    radiotap_hdr_size -= (buffer - buffer_start) % 8;
+    // Add padding until next 8 bytes boundary
+    int padding = 8 - (buffer - buffer_start) % 8;
+    if (padding != 8) {
+        buffer += padding;
+        radiotap_hdr_size -= padding;
+    }
 
     while(true) {
         _radio.flags_32 |= *(const uint32_t*)current_flags;

--- a/src/radiotap.cpp
+++ b/src/radiotap.cpp
@@ -77,10 +77,10 @@ RadioTap::RadioTap(const uint8_t *buffer, uint32_t total_sz)
     std::memcpy(&_radio, buffer, sizeof(_radio));
     uint32_t radiotap_hdr_size = length();
 
-    for (unsigned char i = 0; i < radiotap_hdr_size; i++) {
-        printf("%02x|", *(buffer + i));
-    }
-    printf("\n");
+//    for (unsigned char i = 0; i < radiotap_hdr_size; i++) {
+//        printf("%02x|", *(buffer + i));
+//    }
+//    printf("\n");
 
     check_size(total_sz, radiotap_hdr_size);
     // We start on the first flags field, skipping version, pad and length.
@@ -88,7 +88,7 @@ RadioTap::RadioTap(const uint8_t *buffer, uint32_t total_sz)
     const uint32_t extra_flags_size = find_extra_flag_fields_size(
         buffer + sizeof(uint32_t), total_sz);
     // Find and skip the extra flag fields.
-    printf("Extra flaggs size %d\n", extra_flags_size);
+//    printf("Extra flaggs size %d\n", extra_flags_size);
     buffer += extra_flags_size;
     radiotap_hdr_size -= extra_flags_size;
     // Also skip the header

--- a/src/radiotap.cpp
+++ b/src/radiotap.cpp
@@ -76,17 +76,27 @@ RadioTap::RadioTap(const uint8_t *buffer, uint32_t total_sz)
     const uint8_t *buffer_start = buffer;
     std::memcpy(&_radio, buffer, sizeof(_radio));
     uint32_t radiotap_hdr_size = length();
+
+    for (unsigned char i = 0; i < radiotap_hdr_size; i++) {
+        printf("%02x|", *(buffer + i));
+    }
+    printf("\n");
+
     check_size(total_sz, radiotap_hdr_size);
     // We start on the first flags field, skipping version, pad and length.
     const flags_type* current_flags = (const flags_type*)(buffer + sizeof(uint32_t));
     const uint32_t extra_flags_size = find_extra_flag_fields_size(
         buffer + sizeof(uint32_t), total_sz);
     // Find and skip the extra flag fields.
+    printf("Extra flaggs size %d\n", extra_flags_size);
     buffer += extra_flags_size;
     radiotap_hdr_size -= extra_flags_size;
     // Also skip the header
     buffer += sizeof(_radio);
     radiotap_hdr_size -= sizeof(_radio);
+    // Align start of contents to 8 bytes boundary
+    buffer += (buffer - buffer_start) % 8;
+    radiotap_hdr_size -= (buffer - buffer_start) % 8;
 
     while(true) {
         _radio.flags_32 |= *(const uint32_t*)current_flags;


### PR DESCRIPTION
I got it working with the below changes, both on the Yun, and for reading of the pcap file from Yun on a Ubuntu machine.

The header file was clearly wrong in the ordering of the fields for the big endian version. I also had to align the content of the radiotap to 8 bytes from the start of the buffer. I am not sure that is a proper solution.

Moreover, I cannot see any frames being discarded anymore.