### PR TITLE
add an include guard to config.h

### DIFF
--- a/include/tins/config.h
+++ b/include/tins/config.h
@@ -1,3 +1,5 @@
+#ifndef TINS_CONFIG_H
+#define TINS_CONFIG_H
 
 /* Define if the compiler supports basic C++11 syntax */
 #define HAVE_CXX11
@@ -7,3 +9,5 @@
 
 /* Have WPA2 decryption library */
 #define HAVE_WPA2_DECRYPTION
+
+#endif // TINS_CONFIG_H

--- a/include/tins/config.h.in
+++ b/include/tins/config.h.in
@@ -1,3 +1,5 @@
+#ifndef TINS_CONFIG_H
+#define TINS_CONFIG_H
 
 /* Define if the compiler supports basic C++11 syntax */
 #cmakedefine HAVE_CXX11
@@ -7,3 +9,5 @@
 
 /* Have WPA2 decryption library */
 #cmakedefine HAVE_WPA2_DECRYPTION
+
+#endif // TINS_CONFIG_H


### PR DESCRIPTION
In an internal project we include libtins as a git submodule in a larger project and build it using our own build system. We want to build libtins without WPA2 decryption support but would like not to change a source file in libtins (i.e. the included `config.h`). Since this is currently not possible I added an include guard to `config.h`. This enables us to define `TINS_CONFIG_H` in our build so the default `config.h` does not get used.

Another solution would be to remove the `config.h` from the repository, include it using `#include <config.h>` in the other source files (as [recommended](https://www.gnu.org/software/autoconf/manual/autoconf.html#Configuration-Headers) by autoconf) and generate it inside the build dir using CMake. I think this would be the cleaner solution but since it is more invasive I chose this solution instead. But if you prefer I could implement this change, too.