### PR TITLE
Fixed field name corresponding to IEEE 802.11-2012

### DIFF
--- a/include/tins/dot11/dot11_mgmt.h
+++ b/include/tins/dot11/dot11_mgmt.h
@@ -117,7 +117,7 @@ public:
                      _qos:1,
                      _sst:1,
                      _apsd:1,
-                     _reserved:1,
+                     _radio_measurement:1,
                      _dsss_ofdm:1,
                      _delayed_block_ack:1,
                      _immediate_block_ack:1;
@@ -129,11 +129,11 @@ public:
                      _cf_poll_req:1,
                      _cf_poll:1,
                      _ibss:1,
-                    _ess:1,
-                    _immediate_block_ack:1,
+                     _ess:1,
+                     _immediate_block_ack:1,
                      _delayed_block_ack:1,
                      _dsss_ofdm:1,
-                     _reserved:1,
+                     _radio_measurement:1,
                      _apsd:1,
                      _sst:1,
                      _qos:1,
@@ -225,11 +225,11 @@ public:
         bool apsd() const { return _apsd; }
 
         /**
-         * \brief Getter for the reserved flag.
+         * \brief Getter for the radio measurement flag.
          *
          * \return Bool indicating the flag's value.
          */
-        bool reserved() const { return _reserved; }
+        bool radio_measurement() const { return _radio_measurement; }
 
         /**
          * \brief Getter for the dsss_ofdm flag.
@@ -337,11 +337,11 @@ public:
         void apsd(bool new_value) { _apsd = new_value; }
 
         /**
-         * \brief Setter for the reserved flag.
+         * \brief Setter for the radio measurement flag.
          *
          * \param new_value bool indicating the flag's new value.
          */
-        void reserved(bool new_value) { _reserved = new_value; }
+        void radio_measurement(bool new_value) { _radio_measurement = new_value; }
 
         /**
          * \brief Setter for the dsss_ofdm flag.

--- a/tests/include/tests/dot11_mgmt.h
+++ b/tests/include/tests/dot11_mgmt.h
@@ -61,7 +61,7 @@ inline void test_equals(const capability_information &info1, const capability_in
      EXPECT_EQ(info1.qos(), info2.qos());
      EXPECT_EQ(info1.sst(), info2.sst());
      EXPECT_EQ(info1.apsd(), info2.apsd());
-     EXPECT_EQ(info1.reserved(), info2.reserved());
+     EXPECT_EQ(info1.radio_measurement(), info2.radio_measurement());
      EXPECT_EQ(info1.dsss_ofdm(), info2.dsss_ofdm());
      EXPECT_EQ(info1.delayed_block_ack(), info2.delayed_block_ack());
      EXPECT_EQ(info1.immediate_block_ack(), info2.immediate_block_ack());
@@ -80,7 +80,7 @@ inline void test_equals_empty(const capability_information &info) {
     EXPECT_EQ(info.qos(), 0);
     EXPECT_EQ(info.sst(), 0);
     EXPECT_EQ(info.apsd(), 0);
-    EXPECT_EQ(info.reserved(), 0);
+    EXPECT_EQ(info.radio_measurement(), 0);
     EXPECT_EQ(info.dsss_ofdm(), 0);
     EXPECT_EQ(info.delayed_block_ack(), 0);
     EXPECT_EQ(info.immediate_block_ack(), 0);

--- a/tests/src/dot11/beacon.cpp
+++ b/tests/src/dot11/beacon.cpp
@@ -45,7 +45,7 @@ void test_equals_expected(const Dot11Beacon &dot11) {
     EXPECT_EQ(info.qos(), 0);
     EXPECT_EQ(info.sst(), 0);
     EXPECT_EQ(info.apsd(), 0);
-    EXPECT_EQ(info.reserved(), 0);
+    EXPECT_EQ(info.radio_measurement(), 0);
     EXPECT_EQ(info.dsss_ofdm(), 1);
     EXPECT_EQ(info.delayed_block_ack(), 0);
     EXPECT_EQ(info.immediate_block_ack(), 0);


### PR DESCRIPTION
According to the IEEE802.11 2012 Standard (8.4.1.4 Capability Information field) the flag named reserved is now called "Radio Measurement".