### PR TITLE
Made rsn_information() a const member function 

### DIFF
--- a/include/tins/dot11/dot11_mgmt.h
+++ b/include/tins/dot11/dot11_mgmt.h
@@ -834,7 +834,7 @@ public:
      * 
      * \return std::string containing the ssid.
      */
-    RSNInformation rsn_information();
+    RSNInformation rsn_information() const;
     
     /**
      * \brief Helper method to search for this PDU's SSID.

--- a/src/dot11/dot11_mgmt.cpp
+++ b/src/dot11/dot11_mgmt.cpp
@@ -369,7 +369,7 @@ void Dot11ManagementFrame::vendor_specific(const vendor_specific_type &data) {
 
 // Getters
 
-RSNInformation Dot11ManagementFrame::rsn_information() {
+RSNInformation Dot11ManagementFrame::rsn_information() const {
     return search_and_convert<RSNInformation>(RSN);
 }
 


### PR DESCRIPTION
Made rsn_information() a const member function in order to make Dot11ManagementFrame immutable. 

Otherwise a non const rsn_information() called like this:

    Tins::RSNInformation rsn_info = tins_mgmt_frame->rsn_information();

will result in following compiler error:

    candidate function not viable: no known conversion from 'const Tins::Dot11AssocRequest' to
    'Tins::Dot11ManagementFrame' for object argument RSNInformation rsn_information();
