### PR TITLE
Added channel_map_type

### DIFF
--- a/include/tins/dot11/dot11_mgmt.h
+++ b/include/tins/dot11/dot11_mgmt.h
@@ -71,8 +71,8 @@ public:
     /**
      * \brief Enum used in the reason code field.
      *
-     * These  can be used to get or set the second value of
-     * ibss_dfs_params().channel_map
+     * This enumeration can be used to get or set the reason code field in a
+     * Deauthentication or Disassociation
      */
     enum ReasonCodes {
         UNSPECIFIED = 1,
@@ -119,7 +119,7 @@ public:
         BSS                 = 0x1,
         OFDM_PREAMBLE       = 0x2,
         UNIDENTIFIED_SIGNAL = 0x4,
-        RADARE              = 0x8,
+        RADAR               = 0x8,
         UNMEASURED          = 0x10,
         RESERVED            = 0xE0
     };

--- a/include/tins/dot11/dot11_mgmt.h
+++ b/include/tins/dot11/dot11_mgmt.h
@@ -44,6 +44,21 @@ namespace Tins {
 class Dot11ManagementFrame : public Dot11 {
 public:
     /**
+     * \brief Enum that represents the map field within a channels map field.
+     *
+     * These bitmasks can be used to get or set the second value of
+     * ibss_dfs_params().channel_map
+     */
+    enum MapMask {
+        BSS                 = 0x1,
+        OFDM_PREAMBLE       = 0x2,
+        UNIDENTIFIED_SIGNAL = 0x4,
+        RADARE              = 0x8,
+        UNMEASURED          = 0x10,
+        RESERVED            = 0xE0
+    };
+
+    /**
      * The supported rates container type.
      */
     typedef std::vector<float> rates_type;
@@ -52,6 +67,11 @@ public:
      * The supported channels container type.
      */
     typedef std::vector<std::pair<uint8_t, uint8_t> > channels_type;
+
+    /**
+     * The channel map container type.
+     */
+    typedef std::vector<std::pair<uint8_t, uint8_t> > channel_map_type;
 
     /**
      * The requested information container type.
@@ -409,14 +429,14 @@ public:
         
         address_type dfs_owner;
         uint8_t recovery_interval; 
-        channels_type channel_map;
+        channel_map_type channel_map;
        
         ibss_dfs_params() {}
        
         ibss_dfs_params(const address_type &addr, 
-          uint8_t recovery_interval, const channels_type &channels)
+          uint8_t recovery_interval, const channel_map_type &channel_map)
         : dfs_owner(addr), recovery_interval(recovery_interval),
-          channel_map(channels) {}
+          channel_map(channel_map) {}
 
         static ibss_dfs_params from_option(const option &opt);
     };

--- a/include/tins/dot11/dot11_mgmt.h
+++ b/include/tins/dot11/dot11_mgmt.h
@@ -44,21 +44,6 @@ namespace Tins {
 class Dot11ManagementFrame : public Dot11 {
 public:
     /**
-     * \brief Enum that represents the map field within a channels map field.
-     *
-     * These bitmasks can be used to get or set the second value of
-     * ibss_dfs_params().channel_map
-     */
-    enum MapMask {
-        BSS                 = 0x1,
-        OFDM_PREAMBLE       = 0x2,
-        UNIDENTIFIED_SIGNAL = 0x4,
-        RADARE              = 0x8,
-        UNMEASURED          = 0x10,
-        RESERVED            = 0xE0
-    };
-
-    /**
      * The supported rates container type.
      */
     typedef std::vector<float> rates_type;
@@ -83,6 +68,12 @@ public:
      */
     static const PDU::PDUType pdu_flag = PDU::DOT11_MANAGEMENT;
 
+    /**
+     * \brief Enum used in the reason code field.
+     *
+     * These  can be used to get or set the second value of
+     * ibss_dfs_params().channel_map
+     */
     enum ReasonCodes {
         UNSPECIFIED = 1,
         PREV_AUTH_NOT_VALID = 2,
@@ -116,6 +107,21 @@ public:
         REQUESTED_BY_STA_REJECT_SETUP = 38,
         REQUESTED_BY_STA_TIMEOUT = 39,
         PEER_STA_NOT_SUPPORT_CIPHER = 45
+    };
+
+    /**
+     * \brief Enum that represents the map field within a channels map field.
+     *
+     * These bitmasks can be used to get or set the second value of
+     * ibss_dfs_params().channel_map
+     */
+    enum MapMask {
+        BSS                 = 0x1,
+        OFDM_PREAMBLE       = 0x2,
+        UNIDENTIFIED_SIGNAL = 0x4,
+        RADARE              = 0x8,
+        UNMEASURED          = 0x10,
+        RESERVED            = 0xE0
     };
     
     /**


### PR DESCRIPTION
I noticed that channels_type has two different meanings.
It is used in combination with the supported_channels() method and it is part of the ibss_dfs_params struct used in combination with the ibss_dfs() method. Since channels_type has a rather general definition it will work without any problems.

    /**
     * The supported channels container type.
     */
    typedef std::vector<std::pair<uint8_t, uint8_t> > channels_type;

But without looking into the IEEE 802.11 standard I got quite confused by this dual use.

Actually the difference is pretty significant.
In section 8.4.2.20 "Supported Channels element" of IEEE 802.11-2012 channels_type would have the following content:

    channels_type.first == "First Channel Number" field -> integer
    channels_type.second == "Number of Channels" field -> integer

Within the Context of the IBSS DFS as it is described in section 8.4.2.26 "IBSS DFS element" channels_type would represent the channel map field :

    channels_type.first == "Channel Number" field -> integer
    channels_type.second == "Map" -> flags

To avoid any possibility of confusion I introduced an identical typedef called channel_map_type.
I think there are no drawbacks by doing so.

In addition a created an enumeration called MapMask to set the flags of the map field in a convenient way.

