### PR TITLE
Perserve IP protocol when using RawPDU

### DIFF
--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -385,7 +385,7 @@ void IP::write_serialization(uint8_t *buffer, uint32_t total_sz, const PDU* pare
                 Internals::pdu_type_to_id<IP>(inner_pdu()->pdu_type())
             );
         }
-        if(!is_fragmented() || new_flag != 0xff)
+        if(!is_fragmented() && new_flag != 0xff)
             protocol(new_flag);
     }
     


### PR DESCRIPTION
Currently, the IP protocol field for non-fragmented packets is forcibly overwritten to the protocol of the inner PDU even if that PDU is a RawPDU. I believe this behavior contradicts the documentation.

> If this packet has been crafted manually and the inner_pdu is, for example, a RawPDU, then setting the protocol yourself is necessary.

I discovered this when trying to serialize an IP PDU with an inner RawPDU. Despite explicitly setting the protocol of the IP PDU before serialization, it always serialized as `0xff`.