### PR TITLE
getter and setters for ptk, ccmp, keys, pmks, capturer and aps

### DIFF
--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -283,6 +283,26 @@ namespace Crypto {
         void add_access_point(const std::string &ssid, const address_type &addr);
         
         /**
+         * \brief extract address pair of access point and device bssid pair 
+         * by extracting data from dot11 packet.
+         * 
+         * \param dot11.
+         * 
+         * \returns pair of access point and device bssid.
+         */
+        addr_pair extract_addr_pair(const Dot11Data &dot11);
+        
+        /**
+         * \brief extract address pair of access point and device bssid pair 
+         * by extracting data from dot11 packet.
+         * 
+         * \param dot11.
+         * 
+         * \returns pair of access point and device bssid.
+         */
+        addr_pair extract_addr_pair_dst(const Dot11Data &dot11);
+        
+        /**
          * \brief get pmks.
          * 
          * return pmks.
@@ -325,8 +345,6 @@ namespace Crypto {
                 std::make_pair(addr1, addr2) :
                 std::make_pair(addr2, addr1);
         }
-        addr_pair extract_addr_pair(const Dot11Data &dot11);
-        addr_pair extract_addr_pair_dst(const Dot11Data &dot11);
         bssids_map::const_iterator find_ap(const Dot11Data &dot11);
 
         RSNHandshakeCapturer capturer;

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -66,7 +66,7 @@ namespace Crypto {
             
             SessionKeys();
             SessionKeys(const RSNHandshake &hs, const pmk_type &pmk);
-            SessionKeys(const ptk_type &rptk, const bool &ccmp);
+            SessionKeys(const ptk_type &rptk, const bool ccmp);
             SNAP *decrypt_unicast(const Dot11Data &dot11, RawPDU &raw) const;
             const ptk_type &get_ptk() const {
                 return ptk;

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -260,7 +260,7 @@ namespace Crypto {
          */
         bool decrypt(PDU &pdu);
         
-         /**
+        /**
          * \brief add handshakes(keys).
          * 
          * A Dot11Data PDU is looked up inside the provided PDU chain.
@@ -272,7 +272,7 @@ namespace Crypto {
          */
         void try_add_keys(const Dot11Data &dot11, const RSNHandshake &hs);
         
-         /**
+        /**
          * \brief add access point ssid and address.
          * 
          * Add ssid to access point to bssids map if ssid exits in pmks map.
@@ -288,7 +288,7 @@ namespace Crypto {
          * return pmks.
          */
         pmks_map &get_pmks() {
-          return pmks;
+            return pmks;
         }
         
         /**
@@ -296,8 +296,8 @@ namespace Crypto {
          * 
          * return keys to save captured keys or to set provious stored keys.
          */
-         keys_map &get_keys(){
-          return keys;
+        keys_map &get_keys(){
+            return keys;
         }
         
         /**
@@ -305,8 +305,8 @@ namespace Crypto {
          * 
          * return capturer.
          */
-         RSNHandshakeCapturer &get_capturer() {
-          return capturer;
+        RSNHandshakeCapturer &get_capturer() {
+            return capturer;
         }
         
         /**
@@ -317,6 +317,7 @@ namespace Crypto {
         bssids_map &get_aps() {
             return aps;
         }
+        
     private:
         
         addr_pair make_addr_pair(const address_type &addr1, const address_type &addr2) {

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -71,7 +71,7 @@ namespace Crypto {
             const ptk_type &get_ptk() const {
                 return ptk;
             }
-            const bool &get_ccmp() const {
+            bool get_ccmp() const {
                 return is_ccmp;
             }
         private:

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -66,7 +66,7 @@ namespace Crypto {
             
             SessionKeys();
             SessionKeys(const RSNHandshake &hs, const pmk_type &pmk);
-            SessionKeys(const ptk_type &rptk, const bool ccmp);
+            SessionKeys(const ptk_type &rptk, bool ccmp);
             SNAP *decrypt_unicast(const Dot11Data &dot11, RawPDU &raw) const;
             const ptk_type &get_ptk() const {
                 return ptk;

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -202,7 +202,7 @@ namespace Crypto {
          */
         typedef std::pair<address_type, address_type> addr_pair;
         
-         /*
+        /*
          * \brief The type used to store Session Keys against address pair.
          */
         typedef std::map<addr_pair, WPA2::SessionKeys> keys_map;

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -258,7 +258,7 @@ namespace Crypto {
          * \return false if no decryption was performed, or the decryption 
          * failed, true otherwise.
          */
-        virtual bool decrypt(PDU &pdu);
+        bool decrypt(PDU &pdu);
         
          /**
          * \brief add handshakes(keys).

--- a/include/tins/crypto.h
+++ b/include/tins/crypto.h
@@ -68,10 +68,10 @@ namespace Crypto {
             SessionKeys(const RSNHandshake &hs, const pmk_type &pmk);
             SessionKeys(const ptk_type &rptk, const bool &ccmp);
             SNAP *decrypt_unicast(const Dot11Data &dot11, RawPDU &raw) const;
-            const ptk_type get_ptk() const {
+            const ptk_type &get_ptk() const {
                 return ptk;
             }
-            const bool get_ccmp() const {
+            const bool &get_ccmp() const {
                 return is_ccmp;
             }
         private:

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -267,7 +267,7 @@ SessionKeys::SessionKeys(const RSNHandshake &hs, const pmk_type &pmk) {
     is_ccmp = (hs.handshake()[3].key_descriptor() == 2);
 }
 
-SessionKeys::SessionKeys(const ptk_type &rptk, const bool &ccmp) {
+SessionKeys::SessionKeys(const ptk_type &rptk, const bool ccmp) {
     std::copy( rptk.begin(), rptk.end(), ptk.begin());
     is_ccmp = ccmp;
 }

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -267,7 +267,7 @@ SessionKeys::SessionKeys(const RSNHandshake &hs, const pmk_type &pmk) {
     is_ccmp = (hs.handshake()[3].key_descriptor() == 2);
 }
 
-SessionKeys::SessionKeys(const ptk_type &rptk, const bool ccmp) {
+SessionKeys::SessionKeys(const ptk_type &rptk, bool ccmp) {
     std::copy( rptk.begin(), rptk.end(), ptk.begin());
     is_ccmp = ccmp;
 }

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -267,6 +267,11 @@ SessionKeys::SessionKeys(const RSNHandshake &hs, const pmk_type &pmk) {
     is_ccmp = (hs.handshake()[3].key_descriptor() == 2);
 }
 
+SessionKeys::SessionKeys(const ptk_type &rptk, const bool &ccmp) {
+    std::copy( rptk.begin(), rptk.end(), ptk.begin());
+    is_ccmp = ccmp;
+}
+
 SNAP *SessionKeys::ccmp_decrypt_unicast(const Dot11Data &dot11, RawPDU &raw) const {
     RawPDU::payload_type &pload = raw.payload();
     uint8_t MIC[16] = {0};


### PR DESCRIPTION
Hi Matias,

In this pull request added extract_addr_pair and extract_addr_pair_dst as public because while trying to use them in derived class creating access violation, to get rid of that access violation again we need to implement them in derived. Didn't see any reason to avoid them in public along with getter and setters for ptk, ccmp, keys, pmks, capturer and aps. If you feels that's not a good idea please let me know, will remove them from pull request.

Thanks and Regards,
Prasad