### PR TITLE
Incase of tunnel interface(VPN) mac address can be 0

### DIFF
--- a/src/network_interface.cpp
+++ b/src/network_interface.cpp
@@ -224,10 +224,7 @@ NetworkInterface::Info NetworkInterface::info() const {
     InterfaceInfoCollector collector(&info, iface_id, iface_name.c_str());
     info.is_up = false;
     Utils::generic_iface_loop(collector);
-    // If we didn't event get the hw address, this went wrong
-    if(!collector.found_hw) {
-        throw std::runtime_error("Error looking up interface address");
-    }
+
     return info;
 }
 

--- a/src/network_interface.cpp
+++ b/src/network_interface.cpp
@@ -224,7 +224,8 @@ NetworkInterface::Info NetworkInterface::info() const {
     InterfaceInfoCollector collector(&info, iface_id, iface_name.c_str());
     info.is_up = false;
     Utils::generic_iface_loop(collector);
-
+    
+     // If we didn't even get the hw address or ip address, this went wrong
     if(!collector.found_hw && !collector.found_ip) {
         throw std::runtime_error("Error looking up interface address");
     }

--- a/src/network_interface.cpp
+++ b/src/network_interface.cpp
@@ -225,6 +225,10 @@ NetworkInterface::Info NetworkInterface::info() const {
     info.is_up = false;
     Utils::generic_iface_loop(collector);
 
+    if(!collector.found_hw && !collector.found_ip) {
+        throw std::runtime_error("Error looking up interface address");
+    }
+
     return info;
 }
 


### PR DESCRIPTION
I was trying to run interfaces_info.cpp from examples and I got runtime_error exception. This was happening because ifa_addr (struct ifaddrs) is NULL and hence found_hw is set to false. This is valid case and hence I'm removing the exception.

![selection_001](https://cloud.githubusercontent.com/assets/2063470/8830395/a1c17ac4-30b9-11e5-8ab9-e6037c9652ef.png)


