### PR TITLE
Fix absolute paths in exported CMake config file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.1)
 PROJECT(libtins)
 
+INCLUDE(CMakePackageConfigHelpers)
+
 # Compile in release mode by default
 IF(NOT CMAKE_BUILD_TYPE)
     MESSAGE(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
@@ -184,10 +186,12 @@ EXPORT(PACKAGE libtins)
 
 # Create the libtinsConfig.cmake and libtinsConfigVersion.cmake files
 # for the build tree
-SET(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
-CONFIGURE_FILE(
+SET(CONF_INCLUDE_DIRS "include")
+CONFIGURE_PACKAGE_CONFIG_FILE(
     cmake/libtinsConfig.cmake.in
-    "${PROJECT_BINARY_DIR}/libtinsConfig.cmake" @ONLY
+    "${PROJECT_BINARY_DIR}/libtinsConfig.cmake"
+    INSTALL_DESTINATION ${PROJECT_BINARY_DIR}
+    PATH_VARS CONF_INCLUDE_DIRS
 )
 CONFIGURE_FILE(
     cmake/libtinsConfigVersion.cmake.in

--- a/cmake/libtinsConfig.cmake.in
+++ b/cmake/libtinsConfig.cmake.in
@@ -3,9 +3,11 @@
 #  LIBTINS_INCLUDE_DIRS - include directories for libtins
 #  LIBTINS_LIBRARIES    - libraries to link against
 
+@PACKAGE_INIT@
+
 # Compute paths
 get_filename_component(LIBTINS_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(LIBTINS_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+set_and_check(LIBTINS_INCLUDE_DIRS "@PACKAGE_CONF_INCLUDE_DIRS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 if(NOT TARGET libtins AND NOT LIBTINS_BINARY_DIR)


### PR DESCRIPTION
The current CONFIGURE_FILE() command produces a libtinsConfig.cmake
file with a hardcoded absolute path to the include directory.
As a result, the generated config file is not relocatable.

This is especially difficult when cross compiling where it is often
desirable to have a directory that mirrors the root filesystem of
your target (CMAKE_FIND_ROOT_PATH).  Since the config file has
absolute paths, it can't easily be shared amongst team members or
committed to version control.

This commit uses CONFIGURE_PACKAGE_CONFIG_FILE() instead, which
avoids hardcoded paths in the generated config file.

For each PATH_VAR passed in, CMake sets a PACKAGE_<var> variable
that is relative to the installed location of the package.

See http://www.cmake.org/cmake/help/v3.0/module/CMakePackageConfigHelpers.html