### PR TITLE
Added pcap_setdirection to sniffer

### DIFF
--- a/include/tins/sniffer.h
+++ b/include/tins/sniffer.h
@@ -47,6 +47,8 @@ namespace Tins {
     class SnifferIterator;
     class SnifferConfiguration;
 
+    typedef pcap_direction_t tins_direction_t;
+
     /**
      * \class BaseSniffer
      * \brief Base class for sniffers.
@@ -211,6 +213,14 @@ namespace Tins {
          * \param ms The amount of milliseconds.
          */
         void set_timeout(int ms);
+
+        /**
+         * \brief Sets direction for the sniffer.
+         *
+         * This calls pcap_setdirection using the provided parameter.
+         * \param d The direction for the sniffer.
+         */
+        int set_direction(tins_direction_t d);
 
         /**
          * \brief Sets whether to extract RawPDUs or fully parsed packets.
@@ -567,6 +577,12 @@ namespace Tins {
         void set_timeout(unsigned timeout);
 
         /**
+         * Sets the direction option.
+         * \param direction The direction to be set.
+         */
+        void set_direction(tins_direction_t direction);
+
+        /**
          * Sets the immediate mode option.
          * \param enabled The immediate mode option value.
          */
@@ -596,6 +612,7 @@ namespace Tins {
         bool _promisc;
         bool _rfmon;
         bool _immediate_mode;
+        tins_direction_t _direction;
     };
 
     template<class Functor>

--- a/include/tins/sniffer.h
+++ b/include/tins/sniffer.h
@@ -218,7 +218,7 @@ namespace Tins {
          * This calls pcap_setdirection using the provided parameter.
          * \param d The direction for the sniffer.
          */
-        int set_direction(pcap_direction_t d);
+        bool set_direction(pcap_direction_t d);
 
         /**
          * \brief Sets whether to extract RawPDUs or fully parsed packets.

--- a/include/tins/sniffer.h
+++ b/include/tins/sniffer.h
@@ -47,8 +47,6 @@ namespace Tins {
     class SnifferIterator;
     class SnifferConfiguration;
 
-    typedef pcap_direction_t tins_direction_t;
-
     /**
      * \class BaseSniffer
      * \brief Base class for sniffers.
@@ -220,7 +218,7 @@ namespace Tins {
          * This calls pcap_setdirection using the provided parameter.
          * \param d The direction for the sniffer.
          */
-        int set_direction(tins_direction_t d);
+        int set_direction(pcap_direction_t d);
 
         /**
          * \brief Sets whether to extract RawPDUs or fully parsed packets.
@@ -580,7 +578,7 @@ namespace Tins {
          * Sets the direction option.
          * \param direction The direction to be set.
          */
-        void set_direction(tins_direction_t direction);
+        void set_direction(pcap_direction_t direction);
 
         /**
          * Sets the immediate mode option.
@@ -612,7 +610,7 @@ namespace Tins {
         bool _promisc;
         bool _rfmon;
         bool _immediate_mode;
-        tins_direction_t _direction;
+        pcap_direction_t _direction;
     };
 
     template<class Functor>

--- a/src/sniffer.cpp
+++ b/src/sniffer.cpp
@@ -224,6 +224,10 @@ void BaseSniffer::set_timeout(int ms) {
     pcap_set_timeout(handle, ms);
 }
 
+int BaseSniffer::set_direction(tins_direction_t d) {
+	return pcap_setdirection(handle, d);
+}
+
 // ****************************** Sniffer ******************************
 
 Sniffer::Sniffer(const string &device, const SnifferConfiguration& configuration)
@@ -408,7 +412,8 @@ SnifferConfiguration::SnifferConfiguration() :
     _timeout(DEFAULT_TIMEOUT),
     _promisc(false),
     _rfmon(false),
-    _immediate_mode(false)
+    _immediate_mode(false),
+    _direction(PCAP_D_INOUT)
 {
 
 }
@@ -417,6 +422,7 @@ void SnifferConfiguration::configure_sniffer_pre_activation(Sniffer& sniffer) co
 {
     sniffer.set_snap_len(_snap_len);
     sniffer.set_timeout(_timeout);
+
     if ((_flags & BUFFER_SIZE) != 0) {
         sniffer.set_buffer_size(_buffer_size);
     }
@@ -446,6 +452,9 @@ void SnifferConfiguration::configure_sniffer_post_activation(Sniffer& sniffer) c
         if (!sniffer.set_filter(_filter)) {
             throw std::runtime_error("Could not set the filter! ");
         }
+    }
+    if (sniffer.set_direction(_direction) < 0) {
+        throw std::runtime_error("Could not set the direction! ");
     }
 }
 
@@ -481,6 +490,11 @@ void SnifferConfiguration::set_rfmon(bool enabled)
 void SnifferConfiguration::set_timeout(unsigned timeout)
 {
     _timeout = timeout;
+}
+
+void SnifferConfiguration::set_direction(tins_direction_t direction)
+{
+    _direction = direction;
 }
 
 void SnifferConfiguration::set_immediate_mode(bool enabled) 

--- a/src/sniffer.cpp
+++ b/src/sniffer.cpp
@@ -224,7 +224,7 @@ void BaseSniffer::set_timeout(int ms) {
     pcap_set_timeout(handle, ms);
 }
 
-int BaseSniffer::set_direction(tins_direction_t d) {
+int BaseSniffer::set_direction(pcap_direction_t d) {
 	return pcap_setdirection(handle, d);
 }
 
@@ -492,7 +492,7 @@ void SnifferConfiguration::set_timeout(unsigned timeout)
     _timeout = timeout;
 }
 
-void SnifferConfiguration::set_direction(tins_direction_t direction)
+void SnifferConfiguration::set_direction(pcap_direction_t direction)
 {
     _direction = direction;
 }

--- a/src/sniffer.cpp
+++ b/src/sniffer.cpp
@@ -224,8 +224,9 @@ void BaseSniffer::set_timeout(int ms) {
     pcap_set_timeout(handle, ms);
 }
 
-int BaseSniffer::set_direction(pcap_direction_t d) {
-	return pcap_setdirection(handle, d);
+bool BaseSniffer::set_direction(pcap_direction_t d) {
+	bool result = pcap_setdirection(handle, d) != -1;
+	return result;
 }
 
 // ****************************** Sniffer ******************************
@@ -453,7 +454,7 @@ void SnifferConfiguration::configure_sniffer_post_activation(Sniffer& sniffer) c
             throw std::runtime_error("Could not set the filter! ");
         }
     }
-    if (sniffer.set_direction(_direction) < 0) {
+    if (!sniffer.set_direction(_direction)) {
         throw std::runtime_error("Could not set the direction! ");
     }
 }


### PR DESCRIPTION
I have added to the sniffer the the capability of setting the capturing direction with pcap - pcap_setdirection. Now, if you can decide whether you capture all traffic or only incoming or outgoing. This can be particularly interesting for those who only need to capture packets in a single direction, as it was in my case - incoming packets only -  and could not rely on any filter of IP or MAC addresses because of my particular use case. Please, merge if if you find it interesting.