### PR TITLE
don't set key_t to 0 when setting a key, because the two fields are unrelated

### DIFF
--- a/src/eapol.cpp
+++ b/src/eapol.cpp
@@ -229,7 +229,6 @@ void RSNEAPOL::key_length(uint16_t length) {
 
 void RSNEAPOL::key(const key_type& value) {
     key_ = value;
-    header_.key_t = 0;
 }
 
 void RSNEAPOL::key_mic(small_uint<1> flag) {


### PR DESCRIPTION
right now it is being set unconditionally and without reason, regardless of whether it was explicitly changed earlier in the code