### PR TITLE
Fix Cppcheck 1.75 warnings

### DIFF
--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -287,8 +287,8 @@ void DNS::add_additional(const resource& resource){
 
 string DNS::encode_domain_name(const string& dn) {
     string output;
-    size_t last_index(0), index;
     if (!dn.empty()) {
+        size_t last_index(0), index;
         while ((index = dn.find('.', last_index+1)) != string::npos) {
             output.push_back(static_cast<char>(index - last_index));
             output.append(dn.begin() + last_index, dn.begin() + index);

--- a/src/llc.cpp
+++ b/src/llc.cpp
@@ -215,7 +215,7 @@ void LLC::write_serialization(uint8_t* buffer, uint32_t total_sz, const Tins::PD
 			break;
 	}
 
-	for (field_list::const_iterator it = information_fields_.begin(); it != information_fields_.end(); it++) {
+	for (field_list::const_iterator it = information_fields_.begin(); it != information_fields_.end(); ++it) {
         stream.write(it->begin(), it->end());
 	}
 }


### PR DESCRIPTION
- The scope of the variable 'last_index' & 'index' could be reduced.
- Prefer prefix ++/-- operators for non-primitive types.