### PR TITLE
Correct typo preventing user buffer management for server TCP streams.

### DIFF
--- a/src/tcp_ip/stream.cpp
+++ b/src/tcp_ip/stream.cpp
@@ -258,7 +258,7 @@ void Stream::auto_cleanup_client_data(bool value) {
 }
 
 void Stream::auto_cleanup_server_data(bool value) {
-    auto_cleanup_client_ = value;
+    auto_cleanup_server_ = value;
 }
 
 void Stream::enable_ack_tracking() {


### PR DESCRIPTION
Since pull request #149 has stalled, and I've just stubbed my toe on exactly the same bug, I hope this pull request is more suitable for merging.