### PR TITLE
Feature - Skipping ahead in TCP flows.

### DIFF
--- a/include/tins/tcp_ip/data_tracker.h
+++ b/include/tins/tcp_ip/data_tracker.h
@@ -108,7 +108,7 @@ public:
      *
      * \param seq The seqeunce number to skip to.
      */
-    void skipTo(uint32_t seq);
+    void advance_sequence(uint32_t seq);
 
     /**
      * Retrieves the current sequence number

--- a/include/tins/tcp_ip/data_tracker.h
+++ b/include/tins/tcp_ip/data_tracker.h
@@ -87,7 +87,30 @@ public:
      */
     bool process_payload(uint32_t seq, payload_type payload);
 
-    /** 
+    /**
+     * \brief Skip forward to a sequence number
+     *
+     * This allows to recover from packetloss, if we just do not see all packets of
+     * an original stream. This recovery can only sensibly triggered from the application
+     * layer.
+     *
+     * The method does nothing, if the sequence number is smaller or equal to the
+     * current number.
+     *
+     * This method is particularly useful to call from an out of order callback, if
+     * the application wants to skip forward to this out of order block. The application
+     * will then get the normal data callback!
+     *
+     * The method cleans the buffer from all no longer needed fragments.
+     *
+     * IMPORTANT: If you call this method with a sequence number that is not exactly a
+     * TCP fragment boundary, the flow will never recover from this.
+     *
+     * \param seq The seqeunce number to skip to.
+     */
+    void skipTo(uint32_t seq);
+
+    /**
      * Retrieves the current sequence number
      */
     uint32_t sequence_number() const;

--- a/include/tins/tcp_ip/flow.h
+++ b/include/tins/tcp_ip/flow.h
@@ -166,6 +166,24 @@ public:
     void process_packet(PDU& pdu);
 
     /**
+     * \brief Skip forward to a sequence number
+     *
+     * This allows to recover from packet loss, if we just do not see all packets of
+     * an original stream. This recovery can only sensibly triggered from the application
+     * layer.
+     *
+     * This method is particularly useful to call from an out of order callback, if
+     * the application wants to skip forward to this out of order block. The application
+     * will then get the normal data callback!
+     *
+     * IMPORTANT: If you call this method with a sequence number that is not exactly a
+     * TCP fragment boundary, the flow will never recover from this.
+     *
+     * \param seq The sequence number to skip to.
+     */
+    void skipTo(uint32_t seq);
+
+    /**
      * Indicates whether this flow uses IPv6 addresses
      */
     bool is_v6() const;

--- a/include/tins/tcp_ip/flow.h
+++ b/include/tins/tcp_ip/flow.h
@@ -181,7 +181,7 @@ public:
      *
      * \param seq The sequence number to skip to.
      */
-    void skipTo(uint32_t seq);
+    void advance_sequence(uint32_t seq);
 
     /**
      * Indicates whether this flow uses IPv6 addresses

--- a/src/tcp_ip/data_tracker.cpp
+++ b/src/tcp_ip/data_tracker.cpp
@@ -108,7 +108,7 @@ bool DataTracker::process_payload(uint32_t seq, payload_type payload) {
     return added_some;
 }
 
-void DataTracker::skipTo(uint32_t seq) {
+void DataTracker::advance_sequence(uint32_t seq) {
     if (seq_compare(seq, seq_number_) <= 0) {
         return;
     }

--- a/src/tcp_ip/data_tracker.cpp
+++ b/src/tcp_ip/data_tracker.cpp
@@ -108,6 +108,23 @@ bool DataTracker::process_payload(uint32_t seq, payload_type payload) {
     return added_some;
 }
 
+void DataTracker::skipTo(uint32_t seq) {
+    if (seq_compare(seq, seq_number_) <= 0) {
+        return;
+    }
+
+    for (auto it = buffered_payload_.begin(); it != buffered_payload_.end();) {
+        if (seq_compare(it->first, seq) <= 0) {
+            total_buffered_bytes_ -= it->second.size();
+            it = buffered_payload_.erase(it);
+        } else {
+            it++;
+        }
+    }
+
+    seq_number_ = seq;
+}
+
 uint32_t DataTracker::sequence_number() const {
     return seq_number_;
 }

--- a/src/tcp_ip/flow.cpp
+++ b/src/tcp_ip/flow.cpp
@@ -127,8 +127,8 @@ void Flow::process_packet(PDU& pdu) {
     }
 }
 
-void Flow::skipTo(uint32_t seq) {
-    data_tracker_.skipTo(seq);
+void Flow::advance_sequence(uint32_t seq) {
+    data_tracker_.advance_sequence(seq);
 }
 
 void Flow::update_state(const TCP& tcp) {

--- a/src/tcp_ip/flow.cpp
+++ b/src/tcp_ip/flow.cpp
@@ -110,22 +110,25 @@ void Flow::process_packet(PDU& pdu) {
     }
     const uint32_t chunk_end = tcp->seq() + raw->payload_size();
     const uint32_t current_seq = data_tracker_.sequence_number();
-    // If the end of the chunk ends after our current sequence number, process it.
-    if (seq_compare(chunk_end, current_seq) >= 0) {
-        uint32_t seq = tcp->seq();
-        // If we're going to buffer this and we have a buffering callback, execute it
-        if (seq > current_seq && on_out_of_order_callback_) {
-            on_out_of_order_callback_(*this, seq, raw->payload());
-        }
-        if (data_tracker_.process_payload(seq, move(raw->payload()))) {
-            if (on_data_callback_) {
-                on_data_callback_(*this);
-            }
+    // If the end of the chunk ends before the current sequence number or
+    // if we're going to buffer this and we have a buffering callback, execute it
+    if (seq_compare(chunk_end, current_seq) < 0 ||
+            seq_compare(tcp->seq(), current_seq) > 0){
+        if (on_out_of_order_callback_) {
+            on_out_of_order_callback_(*this, tcp->seq(), raw->payload());
         }
     }
-    else if (on_out_of_order_callback_) {
-        on_out_of_order_callback_(*this, tcp->seq(), raw->payload());
+
+    // can process either way, since it will abort immediately if not needed
+    if (data_tracker_.process_payload(tcp->seq(), move(raw->payload()))) {
+        if (on_data_callback_) {
+            on_data_callback_(*this);
+        }
     }
+}
+
+void Flow::skipTo(uint32_t seq) {
+    data_tracker_.skipTo(seq);
 }
 
 void Flow::update_state(const TCP& tcp) {


### PR DESCRIPTION
I was recently using the (new?) stream follower code for TCP streams and had issues with following TCP streams of captures with packet loss. The application layer (HTTP) allowed me to "recover" from gaps in a flow, by realizing that HTTP requests and responses in a stream cannot be reordered, since a subsequent request/response will only be sent after the previous one has been completely received by the server/client, who answers with a response/request.

If packets are lost (not in the original TCP stream, but just while capturing that stream), flows will get stuck and start buffering indefinitely. By registering an out-of-order callback, the application layer can notice that gap and if it detects the start of a new response/request in an out-of-order chunk, can skip ahead in the flow, of course (maybe) discarding some partially received data in between.

I added skipTo functionality to the Flow and the data tracker to allow this. It still caused problems at the beginning of the stream, where it was not guaranteed that the data tracker process_data method was actually called after the out of order callback (the seq_compare with the initial 0 value prevented entering the execution branch and the latter out of order callback call site was used instead). I re-ordered the code a bit to allow this scenario as well.

Finally, there was a comparison of sequence numbers in Flow, which did not use seq_compare, so I fixed that as well.

(If I have the time, I will also investigate the two payload.erase calls in the data tracker, which both use a simple difference of TCP sequence numbers to determine the length of data to cut. I think this does not account for wrapping of sequence numbers: the arithmetic should follow the same RFC 1982 logic as used and implemented in seq_compare. It might be easiest to adjust seq_compare to return the right difference right away and use that for the erase calls.)