### PR TITLE
Fix: Parsing of incomplete packets with Ethernet padding.

### DIFF
--- a/src/ethernetII.cpp
+++ b/src/ethernetII.cpp
@@ -81,6 +81,14 @@ EthernetII::EthernetII(const address_type& dst_hw_addr,
 EthernetII::EthernetII(const uint8_t* buffer, uint32_t total_sz) {
     InputMemoryStream stream(buffer, total_sz);
     stream.read(header_);
+
+    // Check for zero-padding for padded packets
+    if (total_sz == 60 && std::all_of(stream.pointer(),
+                                      stream.pointer() + stream.size(),
+                                      [](uint8_t x) { return x == 0; })) {
+        return;
+    }
+
     // If there's any size left
     if (stream) {
         inner_pdu(

--- a/src/ethernetII.cpp
+++ b/src/ethernetII.cpp
@@ -82,15 +82,15 @@ EthernetII::EthernetII(const uint8_t* buffer, uint32_t total_sz) {
     InputMemoryStream stream(buffer, total_sz);
     stream.read(header_);
 
-    // Check for zero-padding for padded packets
-    if (total_sz == 60 && std::all_of(stream.pointer(),
-                                      stream.pointer() + stream.size(),
-                                      [](uint8_t x) { return x == 0; })) {
-        return;
-    }
-
     // If there's any size left
     if (stream) {
+        // Check for zero-padding for padded packets
+        if (total_sz == 60 && std::all_of(stream.pointer(),
+                                          stream.pointer() + stream.size(),
+                                          [](uint8_t x) { return x == 0; })) {
+            return;
+        }
+
         inner_pdu(
             Internals::pdu_from_flag(
                 (Constants::Ethernet::e)payload_type(), 

--- a/src/ip.cpp
+++ b/src/ip.cpp
@@ -127,6 +127,13 @@ IP::IP(const uint8_t* buffer, uint32_t total_sz)
     }
     update_padded_options_size();
     if (stream) {
+        // Check for zero-padding for padded packets
+        if (total_sz < 60 && std::all_of(stream.pointer(),
+                                         stream.pointer() + stream.size(),
+                                         [](uint8_t x) { return x == 0; })) {
+            return;
+        }
+
         // Don't avoid consuming more than we should if tot_len is 0,
         // since this is the case when using TCP segmentation offload
         if (tot_len() != 0) {


### PR DESCRIPTION
The current parsing code for EthernetII parses the header, then the next PDU indicated by the payload type, **if** there is anything left in the stream. As a consequence, the parser fails with malformed_packet, if the remainder of the packet was padding introduced as trailer on a prior serialize call.

I added a check that sees if the total size is 60 (i.e. padded ethernet) and if the remainder of the stream is all zeros, in which case I just return from the parse. This allows to parse Ethernet-only packets that were previously unparsed by libTins, even though the payload_type is still set to something like IP.