### PR TITLE
Changes to stream/flow initialization (stream attachment and sequence numbers)

### DIFF
--- a/src/tcp_ip/flow.cpp
+++ b/src/tcp_ip/flow.cpp
@@ -140,7 +140,6 @@ void Flow::update_state(const TCP& tcp) {
             ack_tracker_ = AckTracker(tcp.ack_seq());
         #endif // TINS_HAVE_ACK_TRACKER
         state_ = ESTABLISHED;
-        data_tracker_.sequence_number(data_tracker_.sequence_number() + 1);
     }
     else if (state_ == UNKNOWN && (tcp.flags() & TCP::SYN) != 0) {
         // This is the server's state, sending it's first SYN|ACK
@@ -148,7 +147,7 @@ void Flow::update_state(const TCP& tcp) {
             ack_tracker_ = AckTracker(tcp.ack_seq());
         #endif // TINS_HAVE_ACK_TRACKER
         state_ = SYN_SENT;
-        data_tracker_.sequence_number(tcp.seq());
+        data_tracker_.sequence_number(tcp.seq() + 1);
         const TCP::option* mss_option = tcp.search_option(TCP::MSS);
         if (mss_option) {
             mss_ = mss_option->to<uint16_t>();

--- a/src/tcp_ip/stream.cpp
+++ b/src/tcp_ip/stream.cpp
@@ -62,8 +62,6 @@ Stream::Stream(PDU& packet, const timestamp_type& ts)
 : client_flow_(extract_client_flow(packet)),
   server_flow_(extract_server_flow(packet)), create_time_(ts), 
   last_seen_(ts), auto_cleanup_client_(true), auto_cleanup_server_(true) {
-    // Update client flow state
-    client_flow().process_packet(packet);
     const EthernetII* eth = packet.find_pdu<EthernetII>();
     if (eth) {
         client_hw_addr_ = eth->src_addr();

--- a/tests/src/tcp_ip.cpp
+++ b/tests/src/tcp_ip.cpp
@@ -354,7 +354,7 @@ TEST_F(FlowTest, StreamFollower_ThreeWayHandshake) {
     EXPECT_EQ(Flow::ESTABLISHED, stream.client_flow().state());
     EXPECT_EQ(Flow::SYN_SENT, stream.server_flow().state());
     EXPECT_EQ(30U, stream.client_flow().sequence_number());
-    EXPECT_EQ(60U, stream.server_flow().sequence_number());
+    EXPECT_EQ(61U, stream.server_flow().sequence_number());
     EXPECT_EQ(IPv4Address("4.3.2.1"), stream.client_flow().dst_addr_v4());
     EXPECT_EQ(25, stream.client_flow().dport());
     EXPECT_EQ(IPv4Address("1.2.3.4"), stream.server_flow().dst_addr_v4());


### PR DESCRIPTION
I would like to offer/discuss these changes to TCPIP::Stream/StreamFollower/Flow:

(a) Flow sequence numbers during/after SYN/ACK.
Currently, the sequence number from the observed SYN packet is taken to initialize the data_tracker of the respective flow. The sequence number is then incremented by 1 once the flow itself sends an ACK (since the flow will not see the ACK to its own SYN). I think this is odd and means after the initial exchange of SYN, SYN/ACK, ACK, the client flow sequence number is correct, but the server flow sequence number is still off by one.

My proposed change is to handle flow sequence numbers during SYN/ACK the same way they are handled during payload processing: They are incremented directly on observing packets that contained the data. For SYN packets that means the correct sequence number of the flow is the sequence number of the packet +1 (i.e. interpret sending SYN as sending one byte). The whole change is done by changing two lines in the current code.

So is the current implementation wrong in some way? I think the current implementation will work, since even if the server is the first to send data (based on the off-by-one sequence number), the server will still ACK (since ACK is always on, with the only exception being the initial client SYN). The server flow sequence number is corrected by this automatic ACK in update_state. 

I would still recommend the change to correct the observed sequence numbers by users of the stream_follower and its callbacks. (Edit: I just realized that libTins currently has no callbacks where users could observe this; I added per-packet callbacks to streams in my application... Nevertheless, I currently think the change would conceptually make sense and streamline the implementation.)

(b) I am interested in attaching to already running streams, since the capture files I process simply do not always contain the original SYN/ACK phase. I have seen there is such a flag in the code already and exposed it via the stream_follower constructor to use it. Is this feature work in progress?

To make it work (at least so far, can't vouch for the feature completely working with this change), I had to remove the "client_flow().process_packet()" in Stream constructor. This call seems very odd to me anyway, seems to be a workaround with the intention given in the comment: "Update client flow state". This might make sense for streams created by SYN/ACK, but not if attaching to streams later on.

So I removed this call and instead always process packets. The existing code always processed packets of existing streams, so I have no idea why we would not process the initial SYN packet as well. The only other case where processing was disabled was when no stream was found an none was created (which makes sense). So I removed the bool flag and just return in this case, with the only downside that I had to copy the cleanup code for other streams...

With this change attaching seems to work (so far). I am using it together with "advance_sequence" of #163 to "recover" the flows whenever I detect the beginning of a frame of the application (e.g. HTTP).

I hope this all makes sense and I would like to know if you expect these changes to break anything. The tests are running fine, but note that I adjusted a handshake test to expect sequence number 61 instead of 60 :-)