### PR TITLE
Add CMakeLists options LIBTINS_BUILD_EXAMPLES and LIBTINS_BUILD_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.1)
 PROJECT(libtins)
 
+OPTION(LIBTINS_BUILD_EXAMPLES "Build examples" ON)
+OPTION(LIBTINS_BUILD_TESTS "Build tests" ON)
+
 # Compile in release mode by default
 IF(NOT CMAKE_BUILD_TYPE)
     MESSAGE(STATUS "Setting build type to 'RelWithDebInfo' as none was specified.")
@@ -262,36 +265,41 @@ ADD_CUSTOM_TARGET(uninstall
 # ******************
 ADD_SUBDIRECTORY(include)
 ADD_SUBDIRECTORY(src)
-IF(LIBTINS_ENABLE_PCAP)
-    ADD_SUBDIRECTORY(examples)
-ELSE()
-    MESSAGE(STATUS "Not building examples as pcap support is disabled")
+
+IF(LIBTINS_BUILD_EXAMPLES)
+    IF(LIBTINS_ENABLE_PCAP)
+        ADD_SUBDIRECTORY(examples)
+    ELSE()
+        MESSAGE(STATUS "Not building examples as pcap support is disabled")
+    ENDIF()
 ENDIF()
 
-# Only include googletest if the git submodule has been fetched
-IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest/CMakeLists.txt")
-    # Enable tests and add the test directory
-    MESSAGE(STATUS "Tests have been enabled")
-    SET(GOOGLETEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
-    SET(GOOGLETEST_INCLUDE ${GOOGLETEST_ROOT}/googletest/include)
-    SET(GOOGLETEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest)
-    SET(GOOGLETEST_LIBRARY ${GOOGLETEST_BINARY_DIR}/googletest)
+IF(LIBTINS_BUILD_TESTS)
+    # Only include googletest if the git submodule has been fetched
+    IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest/CMakeLists.txt")
+        # Enable tests and add the test directory
+        MESSAGE(STATUS "Tests have been enabled")
+        SET(GOOGLETEST_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
+        SET(GOOGLETEST_INCLUDE ${GOOGLETEST_ROOT}/googletest/include)
+        SET(GOOGLETEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest)
+        SET(GOOGLETEST_LIBRARY ${GOOGLETEST_BINARY_DIR}/googletest)
 
-    ExternalProject_Add(
-        googletest
-        DOWNLOAD_COMMAND ""
-        SOURCE_DIR ${GOOGLETEST_ROOT}
-        BINARY_DIR ${GOOGLETEST_BINARY_DIR}
-        CMAKE_CACHE_ARGS "-DBUILD_GTEST:bool=ON" "-DBUILD_GMOCK:bool=OFF"
-                         "-Dgtest_force_shared_crt:bool=ON"
-        INSTALL_COMMAND ""
-    )
-    # Make sure we build googletest before anything else
-    ADD_DEPENDENCIES(tins googletest)
-    ENABLE_TESTING()
-    ADD_SUBDIRECTORY(tests)
-ELSE()
-    MESSAGE(STATUS "googletest git submodule is absent. Run `git submodule init && git submodule update` to get it")
+        ExternalProject_Add(
+            googletest
+            DOWNLOAD_COMMAND ""
+            SOURCE_DIR ${GOOGLETEST_ROOT}
+            BINARY_DIR ${GOOGLETEST_BINARY_DIR}
+            CMAKE_CACHE_ARGS "-DBUILD_GTEST:bool=ON" "-DBUILD_GMOCK:bool=OFF"
+                            "-Dgtest_force_shared_crt:bool=ON"
+            INSTALL_COMMAND ""
+        )
+        # Make sure we build googletest before anything else
+        ADD_DEPENDENCIES(tins googletest)
+        ENABLE_TESTING()
+        ADD_SUBDIRECTORY(tests)
+    ELSE()
+        MESSAGE(STATUS "googletest git submodule is absent. Run `git submodule init && git submodule update` to get it")
+    ENDIF()
 ENDIF()
 
 # **********************************


### PR DESCRIPTION
This is to have control over the building of the examples and tests from e.g. parent CMake projects or from the command-line.

I left the default to still be building tests and examples by default.