### PR TITLE
Fixed compile failure somehow related to macro

### DIFF
--- a/include/tins/ip_address.h
+++ b/include/tins/ip_address.h
@@ -202,9 +202,9 @@ private:
 
 #if TINS_IS_CXX11
 namespace std {
-
+template<typename T> struct hash; 
 template<>
-TINS_API struct hash<Tins::IPv4Address> {
+struct hash<Tins::IPv4Address> {
     size_t operator()(const Tins::IPv4Address& addr) const;
 };
 

--- a/include/tins/ipv6_address.h
+++ b/include/tins/ipv6_address.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <iosfwd>
 #include <stdint.h>
+#include <functional> 
 #include "cxxstd.h"
 #include "macros.h"
 
@@ -220,9 +221,9 @@ private:
 
 #if TINS_IS_CXX11
 namespace std {
-
+template<typename T> struct hash; 
 template<>
-TINS_API struct hash<Tins::IPv6Address> {
+struct hash<Tins::IPv6Address> {
     size_t operator()(const Tins::IPv6Address& addr) const;
 };
 


### PR DESCRIPTION
Had three different machines here running Windows 10 with Visual Studio 2017 and 2015.  For current and clean master and develop branches with virtually every combination of options, compilation was failing out of the box with 800+ errors.  The exact cause was not clear, but Klemens made these two changes and compilation is now successful. Maybe from the change you can figure it out.  We could see that appveyor was able to compile, so it was a mystery what the difference was.  Hopefully, this change is trivial enough that you don't mind making it (assuming CI succeeds). 