### PR TITLE
Fix header install location.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,11 +343,10 @@ INSTALL(
     COMPONENT dev
 )
 
-#Recursively list of all headers, with paths relative to include/tins
-FILE(GLOB_RECURSE INCLUDE_FILES "include/tins/*.h")
-
+# Install all headers in include/
 INSTALL(
-    FILES ${INCLUDE_FILES} 
-    DESTINATION .
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION include
     COMPONENT Headers
+    FILES_MATCHING PATTERN "*.h*"
 )


### PR DESCRIPTION
Hi Matias,

When running `make install` on both Linux and macOS systems, the headers were being installed as `/usr/local/*.h` rather than the expected `/usr/local/include/tins/.*`.

Small PR to adjust the install location so that all headers and structure are copied as expected.

Best wishes,

Alex