### PR TITLE
Implemented matching for ND protocol related ICMPv6 messages

### DIFF
--- a/src/icmpv6.cpp
+++ b/src/icmpv6.cpp
@@ -279,6 +279,10 @@ bool ICMPv6::matches_response(const uint8_t* ptr, uint32_t total_sz) const {
         return hdr_ptr->u_echo.identifier == header_.u_echo.identifier &&
                hdr_ptr->u_echo.sequence == header_.u_echo.sequence;
     }
+    else if ( (type() == ROUTER_SOLICIT && hdr_ptr->type == ROUTER_ADVERT) ||
+        (type() == NEIGHBOUR_SOLICIT && hdr_ptr->type == NEIGHBOUR_ADVERT) ) {
+	return hdr_ptr->code == 0;
+    }
     return false;
 }
 


### PR DESCRIPTION
I was trying to implement IPv6 next hop determination since some functions in my application require that I deliver packets with Ethernet frames attached to PacketSender and I needed next-hop link-layer info for the construction. I noticed that send_recv() does not correctly match ICMPv6 ND protocol responses since the checks are not implemented. I added the check of the flags and check if code equals zero according to https://tools.ietf.org/html/rfc4861#page-39 to ICMPv6 response matching.