### PR TITLE
Ensure TCP::OptionTypes has 8-bit range

### DIFF
--- a/include/tins/tcp.h
+++ b/include/tins/tcp.h
@@ -109,7 +109,9 @@ public:
         SACK_OK = 4,
         SACK    = 5,
         TSOPT   = 8,
-        ALTCHK  = 14
+        ALTCHK  = 14,
+        RFC_EXPERIMENT_1 = 253,
+        RFC_EXPERIMENT_2 = 254
     };
     
     /**


### PR DESCRIPTION
When reading TCP packets with esoteric (or corrupt) values for option types, the ubsan fsanitize=enum will trigger if the read value is not in range of the enum. The range of an enum without fixed underlying type is determined by the highest bit set in any of its enumerators, so if `TCP::OptionTypes` has highest enumerator `ALTCHK  = 14` it cannot take values above 15.

Define enumerators [per IANA](https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xhtml#tcp-parameters-1) with bit 7 set to ensure that `TCP::OptionTypes` can take any 8-bit value.

An alternative (C++11 only) would be to give `TCP::OptionTypes` underlying type `uint8_t`.