### PR TITLE
Fix #263 - Install only the headers which are enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,12 +341,4 @@ INSTALL(
     EXPORT libtinsTargets
     DESTINATION CMake
     COMPONENT dev
-)
-
-# Install all headers in include/
-INSTALL(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
-    DESTINATION include
-    COMPONENT Headers
-    FILES_MATCHING PATTERN "*.h*"
-)
+)x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,4 +341,4 @@ INSTALL(
     EXPORT libtinsTargets
     DESTINATION CMake
     COMPONENT dev
-)x
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -223,3 +223,14 @@ INSTALL(
     ARCHIVE DESTINATION lib
     COMPONENT dev
 )
+
+MACRO(INSTALL_HEADERS_WITH_DIRECTORY HEADER_LIST)
+    FOREACH(HEADER ${HEADERS})
+        # Extract directory name and remove leading '../'
+        get_filename_component(DIR ${HEADER} PATH)
+        STRING(REGEX REPLACE "^\\.\\.\\/" "" DIR ${DIR})
+        INSTALL(FILES ${HEADER} DESTINATION ${DIR})
+    ENDFOREACH(HEADER)
+ENDMACRO()
+
+INSTALL_HEADERS_WITH_DIRECTORY(${HEADERS})


### PR DESCRIPTION
Hi Matias,

I saw you'd raised #263 - hadn't realised that was a requirement or the intended behaviour.

This PR uses the HEADERS list we'd defined previously to add the includes to the IDE, and installs those headers.

Best wishes,

Alex