### PR TITLE
Don't include dot11.h in tins.h if it is not configured in the library

### DIFF
--- a/include/tins/tins.h
+++ b/include/tins/tins.h
@@ -40,7 +40,9 @@
 #include <tins/llc.h>
 #include <tins/icmp.h>
 #include <tins/icmpv6.h>
+#if defined(TINS_HAVE_DOT11)
 #include <tins/dot11.h>
+#endif
 #include <tins/dot1q.h>
 #include <tins/dot3.h>
 #include <tins/ip.h>


### PR DESCRIPTION
I build the library with LIBTINS_ENABLE_DOT11=0. The installation procedure removes tins/dot11.h and tins/dot11/*.h from list of headers to install. Therefore, tins.h must not try to include dot11.h in this configuration of the library.
