### PR TITLE
ubsan: don't call &* on possibly null iterator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,55 @@
+##### v4.0 - Mon Dec  4 00:04:30 UTC 2017
+
+- Add parent PDU to each PDU.
+
+- Removed parent PDU parameter on `PDU::write_serialization`.
+
+- Split `utils.h` into multiple files under the `utils` directory.
+
+- Split `internals.h` into multiple files under the `detail` directory.
+
+- Improve compilation times by removing useless include directives.
+
+- Refactor `PDUOption` conversions so that heavy headers are not included in source file.
+
+- Use `std::vector` instead of `std::list` in `TCP`, `IP`, `IPv6`, `DHCP`, `DHCPv6`, `DNS`, `LLC`, `Dot11` and `PPPoE`.
+
+- Improve performance on `IP`, `IPv6` and `TCP` by compiting option sizes during serialization.
+
+- Minor performance improvements in `DNS`.
+
+- Fix `IPv6` next header handling. Now each one contains its own type and the next type is only set during serialization for ease of use.
+
+- Refactor `RadioTap` parsing and serialization using a generic parser/writer.
+
+- Add `BaseSniffer::set_pcap_sniffing_method` to specify whether `pcap_loop` or `pcap_dispatch` should be used when sniffing.
+
+- Use `IFF_POINTOPOINT` on BSD when getting broadcast address for an interface.
+
+- Added cipher and akm suites from 802.11-2016.
+
+- Add IPv6 layer parsing on `Loopback` packets.
+
+- Allow serializing `Loopback` on Windows.
+
+- Use the right flag on `Loopback` for `IPv6`.
+
+- Use the first fragment as a base when reassembling `IP` packets in `IPv4Reassembler`.
+
+- Restructure CMake files removing useless `CMakeLists.txt` in `include` paths.
+
+- Add getter/setter for "more data" field in `Dot11Base`.
+
+- Implemented matching for ND protocol related ICMPv6 messages.
+
+- Ensure TCP::OptionTypes has 8-bit range.
+
+- Add header files into CMake sources so IDE can pick them up.
+
+- Add MPLS "experimental" field.
+
+- Fix dhcpv6::duid_type constructor from duid_ll.
+
 ##### v3.5 - Sat Apr  1 09:11:58 PDT 2017
 
 - Added Utils::route6_entries

--- a/include/tins/pdu_iterator.h
+++ b/include/tins/pdu_iterator.h
@@ -106,8 +106,8 @@ private:
  */
 template <typename Concrete>
 bool operator==(const PDUIteratorBase<Concrete>& lhs, const PDUIteratorBase<Concrete>& rhs) {
-    const PDU* lhs_pdu = &*static_cast<const Concrete&>(lhs);
-    const PDU* rhs_pdu = &*static_cast<const Concrete&>(rhs);
+    const PDU* lhs_pdu = static_cast<const Concrete&>(lhs).operator->();
+    const PDU* rhs_pdu = static_cast<const Concrete&>(rhs).operator->();
     return lhs_pdu == rhs_pdu;
 }
 
@@ -241,7 +241,7 @@ public:
 
     template <typename OtherIterator>
     PDUIteratorRange(const PDUIteratorRange<OtherIterator>& other)
-    : start_(&*other.begin()), end_(&*other.end()) {
+    : start_(other.begin().operator->()), end_(other.end().operator->()) {
 
     } 
 


### PR DESCRIPTION
Use operator->() instead.

ubsan reports:

src/pdu_iterator.cpp:55:13: runtime error: reference binding to null pointer of type 'const struct PDU'
    #0 0x55c6ca in Tins::PDUIterator::operator*() const src/pdu_iterator.cpp:55
    #1 0x4e33f2 in bool Tins::operator==<Tins::PDUIterator>(Tins::PDUIteratorBase<Tins::PDUIterator> const&, Tins::PDUIteratorBase<Tins::PDUIterator> const&) (tests/pdu_iterator_test+0x4e33f2)
    #2 0x4e0aa2 in bool Tins::operator!=<Tins::PDUIterator>(Tins::PDUIteratorBase<Tins::PDUIterator> const&, Tins::PDUIteratorBase<Tins::PDUIterator> const&) (tests/pdu_iterator_test+0x4e0aa2)
    #3 0x4e3119 in std::iterator_traits<Tins::PDUIterator>::difference_type std::__distance<Tins::PDUIterator>(Tins::PDUIterator, Tins::PDUIterator, std::input_iterator_tag) (tests/pdu_iterator_test+0x4e3119)
    #4 0x4e0935 in std::iterator_traits<Tins::PDUIterator>::difference_type std::distance<Tins::PDUIterator>(Tins::PDUIterator, Tins::PDUIterator) (tests/pdu_iterator_test+0x4e0935)
    #5 0x4dba81 in void PDUIteratorTest::test<Tins::PDUIterator>() (tests/pdu_iterator_test+0x4dba81)
    #6 0x4d837d in PDUIteratorTest_Range_Test::TestBody() tests/src/pdu_iterator_test.cpp:50
    #7 0x5147ea in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (tests/pdu_iterator_test+0x5147ea)
    #8 0x50e593 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (tests/pdu_iterator_test+0x50e593)
    #9 0x4f3bdd in testing::Test::Run() (tests/pdu_iterator_test+0x4f3bdd)
    #10 0x4f44bf in testing::TestInfo::Run() (tests/pdu_iterator_test+0x4f44bf)
    #11 0x4f4b6a in testing::TestCase::Run() (tests/pdu_iterator_test+0x4f4b6a)
    #12 0x4fb654 in testing::internal::UnitTestImpl::RunAllTests() (tests/pdu_iterator_test+0x4fb654)
    #13 0x515bf5 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (tests/pdu_iterator_test+0x515bf5)
    #14 0x50f33d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (tests/pdu_iterator_test+0x50f33d)
    #15 0x4fa22e in testing::UnitTest::Run() (tests/pdu_iterator_test+0x4fa22e)
    #16 0x52236c in RUN_ALL_TESTS() (tests/pdu_iterator_test+0x52236c)
    #17 0x522306 in main (tests/pdu_iterator_test+0x522306)
    #18 0x7f8124c27d5c in __libc_start_main (/lib64/libc.so.6+0x1ed5c)
    #19 0x4d8198  (tests/pdu_iterator_test+0x4d8198)