### PR TITLE
Ignore (possibly malformed) options after EOL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,55 @@
+##### v4.0 - Mon Dec  4 00:04:30 UTC 2017
+
+- Add parent PDU to each PDU.
+
+- Removed parent PDU parameter on `PDU::write_serialization`.
+
+- Split `utils.h` into multiple files under the `utils` directory.
+
+- Split `internals.h` into multiple files under the `detail` directory.
+
+- Improve compilation times by removing useless include directives.
+
+- Refactor `PDUOption` conversions so that heavy headers are not included in source file.
+
+- Use `std::vector` instead of `std::list` in `TCP`, `IP`, `IPv6`, `DHCP`, `DHCPv6`, `DNS`, `LLC`, `Dot11` and `PPPoE`.
+
+- Improve performance on `IP`, `IPv6` and `TCP` by compiting option sizes during serialization.
+
+- Minor performance improvements in `DNS`.
+
+- Fix `IPv6` next header handling. Now each one contains its own type and the next type is only set during serialization for ease of use.
+
+- Refactor `RadioTap` parsing and serialization using a generic parser/writer.
+
+- Add `BaseSniffer::set_pcap_sniffing_method` to specify whether `pcap_loop` or `pcap_dispatch` should be used when sniffing.
+
+- Use `IFF_POINTOPOINT` on BSD when getting broadcast address for an interface.
+
+- Added cipher and akm suites from 802.11-2016.
+
+- Add IPv6 layer parsing on `Loopback` packets.
+
+- Allow serializing `Loopback` on Windows.
+
+- Use the right flag on `Loopback` for `IPv6`.
+
+- Use the first fragment as a base when reassembling `IP` packets in `IPv4Reassembler`.
+
+- Restructure CMake files removing useless `CMakeLists.txt` in `include` paths.
+
+- Add getter/setter for "more data" field in `Dot11Base`.
+
+- Implemented matching for ND protocol related ICMPv6 messages.
+
+- Ensure TCP::OptionTypes has 8-bit range.
+
+- Add header files into CMake sources so IDE can pick them up.
+
+- Add MPLS "experimental" field.
+
+- Fix dhcpv6::duid_type constructor from duid_ll.
+
 ##### v3.5 - Sat Apr  1 09:11:58 PDT 2017
 
 - Added Utils::route6_entries

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -81,7 +81,11 @@ TCP::TCP(const uint8_t* buffer, uint32_t total_sz) {
 
     while (stream.pointer() < header_end) {
         const OptionTypes option_type = (OptionTypes)stream.read<uint8_t>();
-        if (option_type <= NOP) {
+        if (option_type == EOL) {
+            stream.skip(header_end - stream.pointer());
+            break;
+        }
+        else if (option_type == NOP) {
             #if TINS_IS_CXX11
             add_option(option_type, 0);
             #else
@@ -309,7 +313,7 @@ void TCP::write_serialization(uint8_t* buffer, uint32_t total_sz) {
 
     if (options_size < total_options_size) {
         const uint16_t padding = total_options_size - options_size;
-        stream.fill(padding, 1);
+        stream.fill(padding, 0);
     }
 
     uint32_t check = 0;

--- a/tests/src/tcp_test.cpp
+++ b/tests/src/tcp_test.cpp
@@ -13,7 +13,8 @@ using namespace Tins;
 class TCPTest : public testing::Test {
 public:
     static const uint8_t expected_packet[], checksum_packet[],
-                            partial_packet[];
+                            partial_packet[],
+                            malformed_option_after_eol_packet[];
     
     void test_equals(const TCP& tcp1, const TCP& tcp2);
 };
@@ -34,6 +35,11 @@ const uint8_t TCPTest::checksum_packet[] = {
 
 const uint8_t TCPTest::partial_packet[] = {
     142, 210, 0, 80, 60, 158, 102, 111, 10, 2, 46, 161, 80, 24, 0, 229, 247, 192, 0, 0
+};
+
+const uint8_t TCPTest::malformed_option_after_eol_packet[] = {
+    127, 77, 79, 29, 241, 218, 229, 70, 95, 174, 209, 35, 96, 2, 113,
+    218, 0, 0, 31, 174, 0, 1, 2, 4
 };
 
 
@@ -269,6 +275,11 @@ TEST_F(TCPTest, SpoofedOptions) {
     // probably we'd expect it to crash if it's not working, valgrind plx
     EXPECT_EQ(3U, pdu.options().size());
     EXPECT_EQ(pdu.serialize().size(), pdu.size());
+}
+
+TEST_F(TCPTest, MalformedOptionAfterEOL) {
+    TCP tcp(malformed_option_after_eol_packet, sizeof(malformed_option_after_eol_packet));
+    EXPECT_EQ(0U, tcp.options().size());
 }
 
 TEST_F(TCPTest, RemoveOption) {


### PR DESCRIPTION
It is invalid for options (other than EOL) to occur after EOL. However,
most network stacks will stop processing options at EOL, meaning that
any further options will be ignored, including if they make the options
field malformed. We should likewise stop processing at EOL as otherwise
we will reject packets that most network stacks accept.

Similarly, when writing out options use EOL as end padding, instead of
NOP.

Test.