### PR TITLE
Add parsing of well known IPv6 extension headers

### DIFF
--- a/include/tins/exceptions.h
+++ b/include/tins/exceptions.h
@@ -205,6 +205,15 @@ public:
 };
 
 /**
+ * \brief Exception thrown when an IPv6 extension header is being
+ * created from invalid data
+ */
+class invalid_ipv6_extension_header : public exception_base {
+public:
+    invalid_ipv6_extension_header() : exception_base("Invalid IPv6 extension header") { }
+};
+
+/**
  * \brief Generic pcap error
  */
 class pcap_error : public exception_base {

--- a/include/tins/ipv6.h
+++ b/include/tins/ipv6.h
@@ -74,6 +74,11 @@ public:
     typedef std::vector<ext_header> headers_type;
 
     /**
+     * The type used to store an extension header option.
+     */
+    typedef std::pair<uint8_t, std::vector<uint8_t> > header_option_type;
+
+    /**
      * The values used to identify extension headers.
      */
     enum ExtensionHeader {
@@ -104,6 +109,46 @@ public:
      * \param total_sz Size of the buffer pointed by buffer
      */
     static metadata extract_metadata(const uint8_t *buffer, uint32_t total_sz);
+
+    /*
+     * \brief The type used to store Hop-By-Hop Extension Headers
+     */
+    struct hop_by_hop_header {
+        std::vector<header_option_type> options;
+
+        static hop_by_hop_header from_extension_header(const ext_header& hdr);
+    };
+
+    /*
+     * \brief The type used to store Destination Routing Extension Headers
+     */
+    struct destination_routing_header {
+        std::vector<header_option_type> options;
+
+        static destination_routing_header from_extension_header(const ext_header& hdr);
+    };
+
+    /**
+     * \brief The type used to store Routing Extension headers
+     */
+    struct routing_header {
+        uint8_t routing_type;
+        uint8_t segments_left;
+        std::vector<uint8_t> data;
+
+        static routing_header from_extension_header(const ext_header& hdr);
+    };
+
+    /**
+     * \brief The type used to store Fragment Extension headers
+     */
+    struct fragment_header {
+        uint16_t fragment_offset;
+        bool more_fragments;
+        uint32_t identification;
+
+        static fragment_header from_extension_header(const ext_header& hdr);
+    };
 
     /**
      * \brief Constructs an IPv6 object.
@@ -365,6 +410,7 @@ private:
     static void write_header(const ext_header& header, Memory::OutputMemoryStream& stream);
     static bool is_extension_header(uint8_t header_id);
     static uint32_t get_padding_size(const ext_header& header);
+    static std::vector<header_option_type> parse_header_options(const uint8_t* data, size_t size);
 
     TINS_BEGIN_PACK
     struct ipv6_header {

--- a/src/ipv6.cpp
+++ b/src/ipv6.cpp
@@ -69,6 +69,49 @@ PDU::metadata IPv6::extract_metadata(const uint8_t *buffer, uint32_t total_sz) {
     return metadata(header_size, pdu_flag, PDU::UNKNOWN);
 }
 
+IPv6::hop_by_hop_header IPv6::hop_by_hop_header::from_extension_header(const ext_header& hdr) {
+    if (TINS_UNLIKELY(hdr.option() != HOP_BY_HOP)) {
+        throw invalid_ipv6_extension_header();
+    }
+    hop_by_hop_header header;
+    header.options = parse_header_options(hdr.data_ptr(), hdr.data_size());
+    return header;
+}
+
+IPv6::destination_routing_header IPv6::destination_routing_header::from_extension_header(const ext_header& hdr) {
+    if (TINS_UNLIKELY(hdr.option() != DESTINATION_ROUTING_OPTIONS)) {
+        throw invalid_ipv6_extension_header();
+    }
+    destination_routing_header header;
+    header.options = parse_header_options(hdr.data_ptr(), hdr.data_size());
+    return header;
+}
+
+IPv6::routing_header IPv6::routing_header::from_extension_header(const ext_header& hdr) {
+    if (TINS_UNLIKELY(hdr.option() != ROUTING)) {
+        throw invalid_ipv6_extension_header();
+    }
+    Memory::InputMemoryStream stream(hdr.data_ptr(), hdr.data_size());
+    routing_header header;
+    header.routing_type = stream.read<uint8_t>();
+    header.segments_left = stream.read<uint8_t>();
+    header.data = std::vector<uint8_t>(stream.pointer(), stream.pointer() + stream.size());
+    return header;
+}
+
+IPv6::fragment_header IPv6::fragment_header::from_extension_header(const ext_header& hdr) {
+    if (TINS_UNLIKELY(hdr.option() != FRAGMENT)) {
+        throw invalid_ipv6_extension_header();
+    }
+    Memory::InputMemoryStream stream(hdr.data_ptr(), hdr.data_size());
+    fragment_header header;
+    uint16_t field = stream.read_be<uint16_t>();
+    header.fragment_offset = field >> 3;
+    header.more_fragments = field & 1;
+    header.identification = stream.read_be<uint32_t>();
+    return header;
+}
+
 IPv6::IPv6(address_type ip_dst, address_type ip_src, PDU* /*child*/)
 : header_(), next_header_() {
     version(6);
@@ -167,6 +210,33 @@ bool IPv6::is_extension_header(uint8_t header_id) {
 uint32_t IPv6::get_padding_size(const ext_header& header) {
     const uint32_t padding = (header.data_size() + sizeof(uint8_t) * 2) % 8;
     return padding == 0 ? 0 : (8 - padding);
+}
+
+std::vector<IPv6::header_option_type> IPv6::parse_header_options(const uint8_t* data, size_t size)
+{
+    Memory::InputMemoryStream stream(data, size);
+    std::vector<header_option_type> options;
+
+    while (stream.size() > 0) {
+        try {
+            uint8_t option = stream.read<uint8_t>();
+            if (option == OptionType::PAD_1) {
+                continue;
+            }
+            uint8_t size = stream.read<uint8_t>();
+            if (size > stream.size()) {
+                throw invalid_ipv6_extension_header();
+            }
+            if (option != PAD_N) {
+                std::vector<uint8_t> value(stream.pointer(), stream.pointer() + size);
+                options.push_back(std::make_pair(option, value));
+            }
+            stream.skip(size);
+        } catch (const malformed_packet&) {
+            throw invalid_ipv6_extension_header();
+        }
+    }
+    return options;
 }
 
 void IPv6::version(small_uint<4> new_version) {


### PR DESCRIPTION
Add classes for IPv6 extension headers defined in the IPv6 protocol
specification (RFC 2460) as well as functions for creating them from
the IPv6 class' ext_header type.

The currently known extension headers are Hop-By-Hop Option,
Destination Routing, Routing and Fragment.