### PR TITLE
Improvements to IP reassembly and TCP following

### DIFF
--- a/include/tins/ip_reassembler.h
+++ b/include/tins/ip_reassembler.h
@@ -55,10 +55,16 @@ public:
         
     }
     
+    uint16_t trim(uint16_t amount);
+    
     const payload_type& payload() const {
         return payload_;
     }
     
+    size_t size() const {
+        return payload_.size();
+    }
+
     uint16_t offset() const {
         return offset_;
     }
@@ -71,10 +77,11 @@ class TINS_API IPv4Stream {
 public:
     IPv4Stream();
     
-    void add_fragment(IP* ip);
+    size_t add_fragment(IP* ip);
     bool is_complete() const;
     PDU* allocate_pdu() const;
     const IP& first_fragment() const;
+    size_t size() const { return received_size_; }
 private:
     typedef std::vector<IPv4Fragment> fragments_type;
     
@@ -135,7 +142,8 @@ public:
      * technique to be used.
      */
     enum OverlappingTechnique {
-        NONE 
+        NONE,
+        BSD
     };
 
     /**
@@ -184,15 +192,24 @@ public:
      */
     void remove_stream(uint16_t id, IPv4Address addr1, IPv4Address addr2);
 private:
+    static const size_t MAX_BUFFERED_BYTES;
+    static const size_t BUFFERED_BYTES_LOW_THRESHOLD;
+
     typedef std::pair<IPv4Address, IPv4Address> address_pair;
     typedef std::pair<uint16_t, address_pair> key_type;
     typedef std::map<key_type, Internals::IPv4Stream> streams_type;
+    typedef std::vector<key_type> order_type;
 
+    Internals::IPv4Stream& get_stream(key_type key);
+    void remove_stream(key_type key);
+    void prune_streams();
     key_type make_key(const IP* ip) const;
     address_pair make_address_pair(IPv4Address addr1, IPv4Address addr2) const;
     
     streams_type streams_;
+    order_type stream_order;
     OverlappingTechnique technique_;
+    size_t buffered_bytes_;
 };
 
 /**

--- a/include/tins/tcp_ip/stream.h
+++ b/include/tins/tcp_ip/stream.h
@@ -134,6 +134,17 @@ public:
      */
     void process_packet(PDU& packet);
 
+
+    // calls the connection_closed callback
+    // to be used *outside* of stream callbacks, just before deletion.
+    void force_close();
+
+    // prevents further callbacks
+    // to be used *inside* of stream callbacks.
+    // the stream will be deleted when the current callbacks exits.
+    void ignore();
+
+
     /**
      * Getter for the client flow
      */
@@ -153,6 +164,9 @@ public:
      * Getter for the server flow (const)
      */
     const Flow& server_flow() const;
+
+
+    bool is_established() const;
 
     /**
      * \brief Indicates whether this stream is finished.
@@ -254,6 +268,8 @@ public:
      * Getter for the last seen time of this stream
      */
     const timestamp_type& last_seen() const;
+
+    void stream_est_callback(const stream_callback_type& callback);
 
     /**
      * \brief Sets the callback to be executed when the stream is closed
@@ -448,6 +464,7 @@ private:
 
     Flow client_flow_;
     Flow server_flow_;
+    stream_callback_type on_stream_est_;
     stream_callback_type on_stream_closed_;
     stream_callback_type on_client_data_callback_;
     stream_callback_type on_server_data_callback_;
@@ -461,6 +478,7 @@ private:
     bool auto_cleanup_server_;
     bool is_partial_stream_;
     unsigned directions_recovery_mode_enabled_;
+    bool is_ignored_;
 
     #ifdef TINS_HAVE_TCP_STREAM_CUSTOM_DATA
     boost::any user_data_;

--- a/src/tcp_ip/flow.cpp
+++ b/src/tcp_ip/flow.cpp
@@ -133,7 +133,7 @@ void Flow::update_state(const TCP& tcp) {
     else if ((tcp.flags() & TCP::RST) != 0) {
         state_ = RST_SENT;
     }
-    else if (state_ == SYN_SENT && (tcp.flags() & TCP::ACK) != 0) {
+    else if (state_ == SYN_SENT && (tcp.flags() & TCP::SYN) == 0 && (tcp.flags() & TCP::ACK) != 0) {
         #ifdef TINS_HAVE_ACK_TRACKER
             ack_tracker_ = AckTracker(tcp.ack_seq());
         #endif // TINS_HAVE_ACK_TRACKER


### PR DESCRIPTION
Hi Matias,

I have made some changes to libtins for my project, and I think most or all of them will be of value to the libtins community. The changes are as follows:

* Modified src/ip_reassembler.cpp (and include/tins/ip_reassembler.h):
  * Added overlap support ("BSD" technique). See https://www.sans.org/reading-room/whitepapers/detection/ip-fragment-reassembly-scapy-33969
  * Added protection from packets that would be > 65535 after reassembly.
  * Added memory limit (256K). When it is reached, old fragments are removed until a 192K threshold is attained.

* Modified src/tcp_ip/flow.cpp (function Flow::update_state) to correctly handle TCP session establishment when packets are (anomalously) duplicated.

* Modified src/tcp_ip/stream.cpp (and include/tins/tcp_ip/stream.h):
  * Added an event (callback) of "connection establishment". (libtins originally only provided a callback for when a TCP stream is encountered, regardless of establishment).
  * Added Stream::ignore() to enable deletion of the stream from *within* TCP callbacks.
  * Added Stream::force_close() to force invocation of the connection-closed callback before deletion from *outside* of TCP callbacks.

* Modified src/tcp_ip/stream_follower.cpp (and include/tins/tcp_ip/stream_follower.h):
  * Added StreamFollower::max_streams, a limitation on the number of concurrently-handled tcp connections. When the limit is reached, packets belonging to new connections are dropped.
    Zero means no limit.
  * Added StreamFollower::n_streams, a getter for the number of presently-followed streams.
  * Added StreamFollower::discard_stream. This invokes the connection termination callback.

I would like your opinion on which of these improvements you would like to pull, and whether any additional changes are required.
For sure at least two things still need to change:
* The overlap support currently disregards the "technique" specified by the user and is always BSD. Please advise how you would like this implemented in libtins style.
* For performance, the memory limit in ip_reassembler should use list instead of vector for the order of fragment streams. I am working on this.

Thanks,
Guy