### PR TITLE
Extension for IPv4Reassembler to prevent a possible memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/**
 include/tins/config.h
+.vscode/**

--- a/include/tins/ip_reassembler.h
+++ b/include/tins/ip_reassembler.h
@@ -229,6 +229,11 @@ public:
      * \brief Return the current number of incomplete packets
      */
     size_t current_number_incomplete_packages() const;
+
+    /**
+     * \brief Returns the current size of the partial-packet buffer
+     */
+    size_t current_buffer_size_incomplete_packages() const;
 private:
     typedef std::pair<IPv4Address, IPv4Address> address_pair;
     typedef std::pair<uint16_t, address_pair> key_type;
@@ -250,7 +255,7 @@ private:
     StreamCallback stream_overflow_callback_;
     StreamCallback stream_timeout_callback_;
 
-    // Statistic
+    // Statistics
     size_t total_number_complete_packages_;
     size_t total_number_damaged_packages_;
 };

--- a/include/tins/ip_reassembler.h
+++ b/include/tins/ip_reassembler.h
@@ -195,21 +195,40 @@ public:
     void remove_stream(uint16_t id, IPv4Address addr1, IPv4Address addr2);
 
     /**
-     * \brief 
+     * \brief A limit is set for each streams. 
+     * If max_number == 0, then there are no restrictions.
      * 
-     * \param max_number
-     * \param callback
+     * \param max_number Maximum number of packets per stream
+     * \param callback If set, it is called for each overflow stream
      */
     void set_max_number_packets_to_stream(size_t max_number, StreamCallback callback = 0);
 
     /**
-     * \brief
+     * \brief Set the lifetime for each streams. 
+     * The list of existing streams is checked with a specified time step. 
+     * Attention, the check does not occur in a separate thread, 
+     * but on each incoming package.
      * 
-     * \param stream_timeout_ms
-     * \param time_to_check_s
-     * \param callback
+     * \param stream_timeout_ms The lifetime of a single stream (milliseconds)
+     * \param time_to_check_s Time step for verification (seconds)
+     * \param callback If set, it is called for each expired valid stream
      */
     void set_timeout_to_stream(size_t stream_timeout_ms, size_t time_to_check_s = 60, StreamCallback callback = 0);
+
+    /**
+     * \brief Return the total number of complete packets
+     */
+    size_t total_number_complete_packages() const;
+
+    /**
+     * \brief Return the total number of damaged packages
+     */
+    size_t total_number_damaged_packages() const;
+
+    /**
+     * \brief Return the current number of incomplete packets
+     */
+    size_t current_number_incomplete_packages() const;
 private:
     typedef std::pair<IPv4Address, IPv4Address> address_pair;
     typedef std::pair<uint16_t, address_pair> key_type;
@@ -230,6 +249,10 @@ private:
 
     StreamCallback stream_overflow_callback_;
     StreamCallback stream_timeout_callback_;
+
+    // Statistic
+    size_t total_number_complete_packages_;
+    size_t total_number_damaged_packages_;
 };
 
 /**

--- a/include/tins/ip_reassembler.h
+++ b/include/tins/ip_reassembler.h
@@ -30,16 +30,19 @@
 #ifndef TINS_IP_REASSEMBLER_H
 #define TINS_IP_REASSEMBLER_H
 
+#if TINS_IS_CXX11
+    #include <chrono>
+    #include <functional>
+#elif defined(_WIN32)
+    #include <winsock2.h>
+    #include <windows.h>
+#else
+    #include <sys/time.h>
+#endif
+
 #include <vector>
 #include <map>
 #include <list>
-#if TINS_IS_CXX11
-#include <chrono>
-#include <functional>
-#else
-#include <ctime>
-#include <time.h>
-#endif
 #include <tins/pdu.h>
 #include <tins/macros.h>
 #include <tins/ip_address.h>

--- a/src/ip_reassembler.cpp
+++ b/src/ip_reassembler.cpp
@@ -294,4 +294,8 @@ size_t IPv4Reassembler::current_number_incomplete_packages() const {
     return streams_.size();
 }
 
+size_t IPv4Reassembler::current_buffer_size_incomplete_packages() const {
+    return streams_history_.size();
+}
+
 } // Tins

--- a/tests/src/ip_reassembler_test.cpp
+++ b/tests/src/ip_reassembler_test.cpp
@@ -116,6 +116,14 @@ TEST_F(IPv4ReassemblerTest, PacketHasMFAndDF) {
     IPv4Reassembler reassembler;
     reassembler.set_max_number_packets_to_stream(500);
     reassembler.set_timeout_to_stream(1000);
+
     EXPECT_EQ(IPv4Reassembler::FRAGMENTED, reassembler.process(packet1));
+    EXPECT_EQ(0, reassembler.total_number_complete_packages());
+    EXPECT_EQ(1, reassembler.current_number_incomplete_packages());
+    EXPECT_EQ(0, reassembler.total_number_damaged_packages());
+
     EXPECT_EQ(IPv4Reassembler::REASSEMBLED, reassembler.process(packet2));
+    EXPECT_EQ(1, reassembler.total_number_complete_packages());
+    EXPECT_EQ(0, reassembler.current_number_incomplete_packages());
+    EXPECT_EQ(0, reassembler.total_number_damaged_packages());
 }

--- a/tests/src/ip_reassembler_test.cpp
+++ b/tests/src/ip_reassembler_test.cpp
@@ -49,6 +49,8 @@ const size_t IPv4ReassemblerTest::orderings[][11] = {
 
 void IPv4ReassemblerTest::test_packets(const vector<pair<const uint8_t*, size_t> >& vt) {
     IPv4Reassembler reassembler;
+    reassembler.set_max_number_packets_to_stream(500);
+    reassembler.set_timeout_to_stream(1000);
     for(size_t i = 0; i < vt.size(); ++i) {
         EthernetII eth(vt[i].first, (uint32_t)vt[i].second);
         // Set the TTL for the first fragment to 32 so we can make sure the right "base"
@@ -112,6 +114,8 @@ TEST_F(IPv4ReassemblerTest, PacketHasMFAndDF) {
     EXPECT_TRUE(packet1.rfind_pdu<IP>().is_fragmented());
     EXPECT_TRUE(packet2.rfind_pdu<IP>().is_fragmented());
     IPv4Reassembler reassembler;
+    reassembler.set_max_number_packets_to_stream(500);
+    reassembler.set_timeout_to_stream(1000);
     EXPECT_EQ(IPv4Reassembler::FRAGMENTED, reassembler.process(packet1));
     EXPECT_EQ(IPv4Reassembler::REASSEMBLED, reassembler.process(packet2));
 }

--- a/tests/src/ip_reassembler_test.cpp
+++ b/tests/src/ip_reassembler_test.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <string>
 #include <utility>
+#include <tins/cxxstd.h>
 #include <tins/ip_reassembler.h>
 #include <tins/ethernetII.h>
 #include <tins/udp.h>

--- a/tests/src/ip_reassembler_test.cpp
+++ b/tests/src/ip_reassembler_test.cpp
@@ -7,6 +7,20 @@
 #include <tins/udp.h>
 #include <tins/ip.h>
 #include <tins/rawpdu.h>
+#ifdef WIN32
+    #include <windows.h>
+#else
+    #include <unistd.h>
+#endif // win32
+
+void sleepcp(int milliseconds) // Cross-platform sleep function
+{
+    #ifdef WIN32
+        Sleep(milliseconds);
+    #else
+        usleep(milliseconds * 1000);
+    #endif // win32
+}
 
 using std::vector;
 using std::pair;
@@ -50,7 +64,7 @@ const size_t IPv4ReassemblerTest::orderings[][11] = {
 void IPv4ReassemblerTest::test_packets(const vector<pair<const uint8_t*, size_t> >& vt) {
     IPv4Reassembler reassembler;
     reassembler.set_max_number_packets_to_stream(500);
-    reassembler.set_timeout_to_stream(1000);
+    reassembler.set_timeout_to_stream(100);
     for(size_t i = 0; i < vt.size(); ++i) {
         EthernetII eth(vt[i].first, (uint32_t)vt[i].second);
         // Set the TTL for the first fragment to 32 so we can make sure the right "base"
@@ -115,15 +129,51 @@ TEST_F(IPv4ReassemblerTest, PacketHasMFAndDF) {
     EXPECT_TRUE(packet2.rfind_pdu<IP>().is_fragmented());
     IPv4Reassembler reassembler;
     reassembler.set_max_number_packets_to_stream(500);
-    reassembler.set_timeout_to_stream(1000);
+    reassembler.set_timeout_to_stream(100);
+
+    EXPECT_EQ(IPv4Reassembler::FRAGMENTED, reassembler.process(packet1));
+    EXPECT_EQ(IPv4Reassembler::REASSEMBLED, reassembler.process(packet2));
+}
+
+
+TEST_F(IPv4ReassemblerTest, PackageWasDeletedByTimeout) {
+    const uint8_t raw_packet1[] = {
+        0, 80, 86, 173, 75, 110, 170, 0, 4, 0, 10, 4, 8, 0, 69, 0, 0, 124, 146,
+        205, 96, 0, 64, 6, 107, 153, 7, 7, 7, 7, 7, 7, 7, 1, 152, 191, 0, 80,
+        160, 119, 38, 106, 125, 14, 42, 154, 128, 24, 0, 115, 148, 65, 0, 0, 1,
+        1, 8, 10, 4, 255, 180, 163, 4, 255, 176, 151, 71, 69, 84, 32, 47, 49, 46,
+        104, 116, 109, 108, 63, 32, 72, 84, 84, 80, 47, 49, 46, 49, 13, 10, 85,
+        115, 101, 114, 45, 65, 103, 101, 110, 116, 58, 32, 87, 103, 101, 116,
+        47, 49, 46, 49, 51, 46, 52, 32, 40, 108, 105, 110, 117, 120, 45, 103,
+        110, 117, 41, 13, 10, 65, 99, 99, 101, 112, 116, 58, 32, 42, 47, 42, 13
+    };
+    const uint8_t raw_packet2[] = {
+        0, 80, 86, 173, 75, 110, 170, 0, 4, 0, 10, 4, 8, 0, 69, 0, 0, 62, 146,
+        205, 64, 13, 64, 6, 139, 202, 7, 7, 7, 7, 7, 7, 7, 1, 10, 72, 111, 115,
+        116, 58, 32, 55, 46, 55, 46, 55, 46, 49, 13, 10, 67, 111, 110, 110,
+        101, 99, 116, 105, 111, 110, 58, 32, 75, 101, 101, 112, 45, 65, 108,
+        105, 118, 101, 13, 10, 13, 10
+    };
+    EthernetII packet1(raw_packet1, sizeof(raw_packet1));
+    EthernetII packet2(raw_packet2, sizeof(raw_packet2));
+    EXPECT_TRUE(packet1.rfind_pdu<IP>().is_fragmented());
+    EXPECT_TRUE(packet2.rfind_pdu<IP>().is_fragmented());
+    IPv4Reassembler reassembler;
+    reassembler.set_max_number_packets_to_stream(500);
+    reassembler.set_timeout_to_stream(100);
 
     EXPECT_EQ(IPv4Reassembler::FRAGMENTED, reassembler.process(packet1));
     EXPECT_EQ(0, reassembler.total_number_complete_packages());
     EXPECT_EQ(1, reassembler.current_number_incomplete_packages());
     EXPECT_EQ(0, reassembler.total_number_damaged_packages());
+    EXPECT_EQ(1, reassembler.current_buffer_size_incomplete_packages());
 
-    EXPECT_EQ(IPv4Reassembler::REASSEMBLED, reassembler.process(packet2));
-    EXPECT_EQ(1, reassembler.total_number_complete_packages());
-    EXPECT_EQ(0, reassembler.current_number_incomplete_packages());
+    sleepcp(1000);
+
+    EXPECT_EQ(IPv4Reassembler::FRAGMENTED, reassembler.process(packet2));
+    
+    EXPECT_EQ(0, reassembler.total_number_complete_packages());
+    EXPECT_EQ(1, reassembler.current_number_incomplete_packages());
     EXPECT_EQ(0, reassembler.total_number_damaged_packages());
+    EXPECT_EQ(1, reassembler.current_buffer_size_incomplete_packages());
 }


### PR DESCRIPTION
Hello!
I noticed that there is no removal of obsolete packages. If there is a loss in traffic, there will be a memory leak in  IPv4Reassembler (IPv4Stream::fragments_type).
Added two options to prevent this.
On the similarity `pcapplusplus` added the ability to limit the streams (`set_max_number_packets_to_stream`).
And also added the removal of expired streams by the calculation of the time of their lives (`set_timeout_to_stream`).

In a hurry, added support for C++ below 11 version. :) But we need to check in more detail - could be broken cross-platform.

Tested in Linux: Arch [gcc 8.1.1 or clang++ 6.0.0] and CentOS7 [gcc 4.8.3].
Problems occurred in the tests for СentOS7, when we set the flag `-DLIBTINS_ENABLE_CXX11=0`.
The error is related to enum in class IPv6 (While it did not fix it, but maybe it could be similar):
`/home/dev/work/projects/libtins-origin/tests/src/ipv6_test.cpp: В функции-члене «virtual void IPv6Test_HopByHopPadding_Test::TestBody()»:
/home/dev/work/projects/libtins-origin/tests/src/ipv6_test.cpp:366:34: ошибка: «Tins::IPv6::ExtensionHeader» is not a class or namespace
     ipv6_header.add_header(IPv6::ExtensionHeader::HOP_BY_HOP);
                                  ^
/home/dev/work/projects/libtins-origin/tests/src/ipv6_test.cpp: В функции-члене «virtual void IPv6Test_HopByHopParsing_Test::TestBody()»:
/home/dev/work/projects/libtins-origin/tests/src/ipv6_test.cpp:377:67: ошибка: «Tins::IPv6::ExtensionHeader» is not a class or namespace
     const IPv6::ext_header* ext_header = ipv6.search_header(IPv6::ExtensionHeader::HOP_BY_HOP);`

Is there a need for C++ support below version 11? I would say that this is an old version :).