### PR TITLE
Added base class access specifier for socket_close_error

### DIFF
--- a/include/tins/exceptions.h
+++ b/include/tins/exceptions.h
@@ -128,7 +128,7 @@ public:
 /**
  * \brief Exception thrown when PacketSender fails to close a socket.
  */
-class socket_close_error : exception_base {
+class socket_close_error : public exception_base {
 public:
     socket_close_error(const std::string& msg)
     : exception_base(msg) { }


### PR DESCRIPTION
I think the access specifier got lost during commit af71a4eca7b9d284ccca879118871c1b3f070cab.