### PR TITLE
Fix Dot1Q serialization for non-qinq packets

### DIFF
--- a/src/ethernetII.cpp
+++ b/src/ethernetII.cpp
@@ -166,6 +166,8 @@ void EthernetII::write_serialization(uint8_t* buffer, uint32_t total_sz) {
         }
         // Dirty trick: Double Dot1Q is interpreted as Dot1AD
         else if (type == PDU::DOT1Q) {
+            flag = Internals::pdu_flag_to_ether_type(type);
+
             if (inner_pdu()->inner_pdu()) {
                 const PDUType inner_type = inner_pdu()->inner_pdu()->pdu_type();
                 if (inner_type == PDU::DOT1Q) {

--- a/tests/src/dot1q_test.cpp
+++ b/tests/src/dot1q_test.cpp
@@ -58,6 +58,17 @@ TEST_F(Dot1QTest, Serialize) {
     );
 }
 
+TEST_F(Dot1QTest, SerializeCraftedPacket)
+{
+    EthernetII pkt = EthernetII() / Dot1Q(10) / IP("192.168.1.2") / TCP(23, 45) / RawPDU("asdasdasd");
+    PDU::serialization_type buffer = pkt.serialize();
+    EXPECT_EQ(buffer[12], 0x81);
+    EXPECT_EQ(buffer[13], 0x00);
+    EthernetII pkt2(&buffer[0], buffer.size());
+    const Dot1Q &q1 = pkt2.rfind_pdu<Dot1Q>();
+    EXPECT_EQ(10, q1.id());
+}
+
 TEST_F(Dot1QTest, PayloadType) {
     Dot1Q dot1;
     dot1.payload_type(0x9283);


### PR DESCRIPTION
The recent change to serialize QinQ packets properly broke serialization of single VLAN tagged packets. The serialize code in `EthernetII` was not setting the payload type of Dot1Q packets. This PR is a simple fix for that.