### PR TITLE
Fix frame length

### DIFF
--- a/include/tins/ip.h
+++ b/include/tins/ip.h
@@ -281,6 +281,10 @@ public:
 
     /* Getters */
 
+    uint32_t advertised_size() const {
+        return static_cast<uint32_t>(tot_len());
+    }
+
     /**
      * \brief Getter for the header length field.
      *

--- a/include/tins/pdu.h
+++ b/include/tins/pdu.h
@@ -281,6 +281,12 @@ public:
      */
     uint32_t size() const;
 
+    /** \brief The whole chain of PDU's advertised size, including this one.
+     *
+     * Returns the sum of this and all children PDU's advertised size.
+     */
+    virtual uint32_t advertised_size() const;
+
     /**
      * \brief Getter for the inner PDU.
      * \return The current inner PDU. Might be a null pointer.

--- a/src/packet_writer.cpp
+++ b/src/packet_writer.cpp
@@ -70,12 +70,12 @@ void PacketWriter::write(Packet& packet) {
 }
 
 void PacketWriter::write(PDU& pdu, const struct timeval& tv) {
-    PDU::serialization_type buffer = pdu.serialize();
     struct pcap_pkthdr header;
     memset(&header, 0, sizeof(header));
     header.ts = tv;
+    header.len = static_cast<bpf_u_int32>(pdu.advertised_size());
+    PDU::serialization_type buffer = pdu.serialize();
     header.caplen = static_cast<bpf_u_int32>(buffer.size());
-    header.len = static_cast<bpf_u_int32>(buffer.size());
     pcap_dump((u_char*)dumper_, &header, &buffer[0]);
 }
 

--- a/src/pdu.cpp
+++ b/src/pdu.cpp
@@ -85,6 +85,14 @@ uint32_t PDU::size() const {
     return sz;
 }
 
+uint32_t PDU::advertised_size() const {
+    uint32_t result = header_size() + trailer_size();
+    if (inner_pdu_) {
+        result += inner_pdu()->advertised_size();
+    }
+    return result;
+}
+
 void PDU::send(PacketSender &, const NetworkInterface &) { 
     
 }


### PR DESCRIPTION
This pull request should fix issue #300.

I implemented a virtual method `PDU::advertised_size()`, which defaults to the sum of `header_size() + trailer_size()` plus `advertised_size()` of all inner PDUs down to the IP PDU.

The `IP::advertised_size()` method returns the `tot_len` instead.

The PacketWriter now uses this virtual method to determine the frame length before writing the packet out.

Please let me know if this solution is to your liking.