### PR TITLE
Bugfix/crosscompilation does not properly set include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,8 @@ INSTALL(
     COMPONENT dev
 )
 
+TARGET_INCLUDE_DIRECTORIES(tins INTERFACE "$<INSTALL_INTERFACE:include/>")
+
 # Install the export set for use with the install-tree
 INSTALL(
     EXPORT libtinsTargets


### PR DESCRIPTION
After cross-compilation I observe the variable `LIBTINS_INCLUDE_DIRS` in `libtinsConfig.cmake` file contains wrong value. For the reason I slightly rework it and make the include directory part of the target