### PR TITLE
Fix several leaks

### DIFF
--- a/src/offline_packet_filter.cpp
+++ b/src/offline_packet_filter.cpp
@@ -37,11 +37,14 @@ using std::string;
 namespace Tins {
 
 OfflinePacketFilter::OfflinePacketFilter(const OfflinePacketFilter& other) {
-    *this = other;
+    string_filter_ = other.string_filter_;
+    init(string_filter_, pcap_datalink(other.handle_), pcap_snapshot(other.handle_));
 }
 
 OfflinePacketFilter& OfflinePacketFilter::operator=(const OfflinePacketFilter& other) {
     string_filter_ = other.string_filter_;
+    pcap_freecode(&filter_);
+    pcap_close(handle_);
     init(string_filter_, pcap_datalink(other.handle_), pcap_snapshot(other.handle_));
     return* this;
 }

--- a/src/offline_packet_filter.cpp
+++ b/src/offline_packet_filter.cpp
@@ -58,8 +58,14 @@ void OfflinePacketFilter::init(const string& pcap_filter,
         link_type,
         snap_len
     );
+    if (!handle_) {
+        throw pcap_open_failed();
+    }
     if (pcap_compile(handle_, &filter_, pcap_filter.c_str(), 1, 0xffffffff) == -1) {
-        throw invalid_pcap_filter(pcap_geterr(handle_));
+        string error(pcap_geterr(handle_));
+        pcap_freecode(&filter_);
+        pcap_close(handle_);
+        throw invalid_pcap_filter(error.c_str());
     }
 }
 

--- a/src/packet_writer.cpp
+++ b/src/packet_writer.cpp
@@ -86,8 +86,9 @@ void PacketWriter::init(const string& file_name, int link_type) {
     }
     dumper_ = pcap_dump_open(handle_, file_name.c_str());
     if (!dumper_) {
+        string error(pcap_geterr(handle_));
         pcap_close(handle_);
-        throw pcap_error(pcap_geterr(handle_));
+        throw pcap_error(error);
     }
 }
 


### PR DESCRIPTION
This series fixes two issues.

1. Using pcap_geterr after handle_ is closed.
2. Failing to free filter_ and handle_ on construction error.

Found by Valgrind.