### PR TITLE
add IPv6 check for Link-Local unicast address

### DIFF
--- a/include/tins/ipv6_address.h
+++ b/include/tins/ipv6_address.h
@@ -231,9 +231,9 @@ public:
     bool is_multicast() const;
 
     /**
-     * \brief Return true fi this is a Link-Local unicast IPv6 address.
+     * \brief Return true if this is a Link-Local unicast IPv6 address.
      *
-     * This method returns true fi this address is in the address range
+     * This method returns true if this address is in the address range
      * fe80::/10, false otherwise
      */
     bool is_local_unicast() const;

--- a/include/tins/ipv6_address.h
+++ b/include/tins/ipv6_address.h
@@ -231,6 +231,14 @@ public:
     bool is_multicast() const;
 
     /**
+     * \brief Return true fi this is a Link-Local unicast IPv6 address.
+     *
+     * This method returns true fi this address is in the address range
+     * fe80::/10, false otherwise
+     */
+    bool is_local_unicast() const;
+
+    /**
      * \brief Returns the size of an IPv6 Address.
      *
      * This returns the value of IPv6Address::address_size

--- a/src/ipv6_address.cpp
+++ b/src/ipv6_address.cpp
@@ -57,6 +57,7 @@ namespace Tins {
 
 const IPv6Address loopback_address = "::1";
 const AddressRange<IPv6Address> multicast_range = IPv6Address("ff00::") / 8;
+const AddressRange<IPv6Address> local_unicast_range = IPv6Address("fe80::") / 10;
 
 IPv6Address IPv6Address::from_prefix_length(uint32_t prefix_length) {
     IPv6Address address;
@@ -136,6 +137,10 @@ bool IPv6Address::is_loopback() const {
 
 bool IPv6Address::is_multicast() const {
     return multicast_range.contains(*this);
+}
+
+bool IPv6Address::is_local_unicast() const {
+    return local_unicast_range.contains(*this);
 }
 
 ostream& operator<<(ostream& os, const IPv6Address& addr) {


### PR DESCRIPTION
Hi. In our project, it is useful to check if some IPv6 address is link-local. What about to add this check to libtins directly?