### PR TITLE
Flush Packet to PCAP

### DIFF
--- a/src/packet_writer.cpp
+++ b/src/packet_writer.cpp
@@ -77,6 +77,7 @@ void PacketWriter::write(PDU& pdu, const struct timeval& tv) {
     PDU::serialization_type buffer = pdu.serialize();
     header.caplen = static_cast<bpf_u_int32>(buffer.size());
     pcap_dump((u_char*)dumper_, &header, &buffer[0]);
+    pcap_dump_flush(dumper_);
 }
 
 void PacketWriter::init(const string& file_name, int link_type) {


### PR DESCRIPTION
I was doing some work on a Raspberry Pi with libtins. Specifically, I was writing unique beacons to a pcap file. However, at the end of some runs the pcap would be empty. The [PCAP man page](https://www.tcpdump.org/manpages/pcap.3pcap.html) states the following:

> Packets written with pcap_dump() may be buffered, rather than being immediately written to the "savefile". Closing the pcap_dumper_t will cause all buffered-but-not-yet-written packets to be written to the ``savefile''.

Unfortunately, due to the nature of the RPI, the termination of my program is rarely clean. Meaning pcap_close() will almost certainly never be called. A simple work around is to call pcap_dump_flush() after every write to ensure, no matter what, that the packets get written to the pcap file instead of stored in memory indefinitely.