### PR TITLE
Fix compiler warnings from MSVC 2017

### DIFF
--- a/include/tins/icmpv6.h
+++ b/include/tins/icmpv6.h
@@ -173,7 +173,7 @@ public:
         
         addr_list_type(const addresses_type& addresses = addresses_type())
         : addresses(addresses) {
-            std::fill(reserved, reserved + sizeof(reserved), 0);
+            std::fill(reserved, reserved + sizeof(reserved), static_cast<uint8_t>(0));
         }
         
         static addr_list_type from_option(const option& opt);
@@ -199,7 +199,7 @@ public:
         
         naack_type(uint8_t code = 0, uint8_t status = 0)
         : code(code), status(status) {
-            std::fill(reserved, reserved + 4, 0);
+            std::fill(reserved, reserved + 4, static_cast<uint8_t>(0));
         }
         
         static naack_type from_option(const option& opt);
@@ -323,7 +323,7 @@ public:
          * The key_hash member will be 0-initialized.
          */
         rsa_sign_type() {
-            std::fill(key_hash, key_hash + sizeof(key_hash), 0);
+            std::fill(key_hash, key_hash + sizeof(key_hash), static_cast<uint8_t>(0));
         }
 
         static rsa_sign_type from_option(const option& opt);
@@ -489,7 +489,7 @@ public:
 
         timestamp_type(uint64_t timestamp = 0)
         : timestamp(timestamp) {
-            std::fill(reserved, reserved + sizeof(reserved), 0);
+            std::fill(reserved, reserved + sizeof(reserved), static_cast<uint8_t>(0));
         }
 
         static timestamp_type from_option(const option& opt);

--- a/include/tins/ip.h
+++ b/include/tins/ip.h
@@ -174,9 +174,9 @@ public:
         option_identifier(OptionNumber number, OptionClass op_class,
           small_uint<1> copied) 
         #if TINS_IS_LITTLE_ENDIAN
-        : number(number), op_class(op_class), copied(copied) {}
+        : number(static_cast<uint8_t>(number)), op_class(static_cast<uint8_t>(op_class)), copied(copied) {}
         #else
-        : copied(copied), op_class(op_class), number(number) {}
+        : copied(copied), op_class(static_cast<uint8_t>(op_class)), number(static_cast<uint8_t>(number)) {}
         #endif
         
         /**

--- a/include/tins/llc.h
+++ b/include/tins/llc.h
@@ -236,7 +236,7 @@ public:
 	 * \return The LLC frame format.
 	 */
 	uint8_t type() {
-        return type_;
+        return static_cast<uint8_t>(type_);
     }
 
 	/**
@@ -245,7 +245,7 @@ public:
 	 * \return The sender send sequence number if format is INFORMATION else 0.
 	 */
 	uint8_t send_seq_number() {
-		return (type() == INFORMATION) ? (control_field.info.send_seq_num) : 0;
+		return static_cast<uint8_t>((type() == INFORMATION) ? (control_field.info.send_seq_num) : 0);
 	}
 
 	/**


### PR DESCRIPTION
The MS C++ compiler doesn't seem to understand that a small constant
like 0, although strictly being an integer, will fit perfectly fine
into an 8 bit type so add some safe casts to silence that warning.