### PR TITLE
Set CH_SWITCH_TIMING enumerator to the correct value of 104

### DIFF
--- a/include/tins/dot11/dot11_base.h
+++ b/include/tins/dot11/dot11_base.h
@@ -182,7 +182,7 @@ public:
         DMS_RESP,
         LINK_ID,
         WAKEUP_SCHEDULE,
-        CH_SWITCH_TIMING,
+        CH_SWITCH_TIMING = 104,
         PTI_CONTROL,
         TPU_BUFFER_STATUS,
         INTERWORKING,


### PR DESCRIPTION
Set CH_SWITCH_TIMING enumerator to the correct value of 104 as the current one is (implicitly) set to 103 which is reserved.
This also automatically sets correct values of the few following enumerators (PTI_CONTROL through EXT_CAP) due to the way enumerations in C/C++ work:
https://github.com/tsilia/libtins/blob/a06baf335fea27dfca5c72270c3e199fb9e11b52/include/tins/dot11/dot11_base.h#L186-L208

Fixes mfontanini/libtins#371