### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ in order to invalidate it, you should run(as root):
 ldconfig
 ```
 
+## Building libtins - Using vcpkg ##
+
+You can download and install libtins using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libtins
+
+The libtins port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Running tests ##
 
 You may want to run the unit tests on your system so you make sure


### PR DESCRIPTION
Libtins is available as a port in vcpkg, a C++ library manager that simplifies installation for libtins and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libtins, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.