### PR TITLE
fix CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,14 @@ IF(LIBTINS_ENABLE_DOT11)
         ENDIF()
     ELSE(LIBTINS_ENABLE_WPA2)
         MESSAGE(STATUS "Disabling WPA2 decryption support.")
+        # Default this to empty strings
+        SET(OPENSSL_INCLUDE_DIR "")
+        SET(OPENSSL_LIBRARIES "")
     ENDIF(LIBTINS_ENABLE_WPA2)
+ELSE(LIBTINS_ENABLE_DOT11)
+    # Default this to empty strings
+    SET(OPENSSL_INCLUDE_DIR "")
+    SET(OPENSSL_LIBRARIES "")
 ENDIF(LIBTINS_ENABLE_DOT11)
 
 # Optionally enable TCPIP classes (on by default)


### PR DESCRIPTION
add missing openssl cmake variables, when dot11 or WPA2 are disable.
 
When dot11 or WPA2 are disable the  variable OPENSSL_INCLUDE_DIR  will be still in used
 
see https://github.com/mfontanini/libtins/blob/master/src/CMakeLists.txt#L12