### PR TITLE
generate config.h in binary directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ ENDIF(DOXYGEN_FOUND)
 # Configuration file
 CONFIGURE_FILE(
   "${PROJECT_SOURCE_DIR}/include/tins/config.h.in"
-  "${PROJECT_SOURCE_DIR}/include/tins/config.h"
+  "${PROJECT_BINARY_DIR}/include/tins/config.h"
 )
 
 IF (NOT CMAKE_INSTALL_LIBDIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ INCLUDE_DIRECTORIES(BEFORE
     ${OPENSSL_INCLUDE_DIR}
     ${PCAP_INCLUDE_DIR}
     ${LIBTINS_INCLUDE_DIR}
+    ${PROJECT_BINARY_DIR}/include
 )
 
 set(SOURCES
@@ -82,7 +83,7 @@ set(HEADERS
     ${LIBTINS_INCLUDE_DIR}/tins/handshake_capturer.h
     ${LIBTINS_INCLUDE_DIR}/tins/stp.h
     ${LIBTINS_INCLUDE_DIR}/tins/pppoe.h
-    ${LIBTINS_INCLUDE_DIR}/tins/config.h
+    ${PROJECT_BINARY_DIR}/include/tins/config.h
     ${LIBTINS_INCLUDE_DIR}/tins/constants.h
     ${LIBTINS_INCLUDE_DIR}/tins/crypto.h
     ${LIBTINS_INCLUDE_DIR}/tins/cxxstd.h


### PR DESCRIPTION
I found that libtins got recompile everytime which drive me crazy when I switched debug/release mode or when I switched from win32/linux. 
The reason is the cmake generates config.h for those build types and got the config.h overwritten, which causing the compiler to recompile the whole project.
I suggest to generate config.h in binary directory. That make every config.h stay with there own build type.