### PR TITLE
Fix TCP option size calculation for options with empty payload

### DIFF
--- a/include/tins/tcp.h
+++ b/include/tins/tcp.h
@@ -110,6 +110,7 @@ public:
         SACK    = 5,
         TSOPT   = 8,
         ALTCHK  = 14,
+        SCPS_CAPABILITIES = 20,
         RFC_EXPERIMENT_1 = 253,
         RFC_EXPERIMENT_2 = 254
     };

--- a/src/tcp.cpp
+++ b/src/tcp.cpp
@@ -385,8 +385,10 @@ uint32_t TCP::calculate_options_size() const {
     for (options_type::const_iterator iter = options_.begin(); iter != options_.end(); ++iter) {
         const option& opt = *iter;
         options_size += sizeof(uint8_t);
-        // SACK_OK contains length but not data
-        if (opt.data_size() || opt.option() == SACK_OK) {
+        // Options 0 and 1 are exactly one octet which is their kind field.
+        // All other options have their one octet kind field,
+        // followed by a one octet length field (even if the option payload is empty)
+        if (opt.option() != 0 && opt.option() != 1) {
             options_size += sizeof(uint8_t);    
             options_size += static_cast<uint16_t>(opt.data_size());
         }

--- a/tests/src/tcp_test.cpp
+++ b/tests/src/tcp_test.cpp
@@ -277,6 +277,14 @@ TEST_F(TCPTest, SpoofedOptions) {
     EXPECT_EQ(pdu.serialize().size(), pdu.size());
 }
 
+TEST_F(TCPTest, OptionWithEmptyPayload) {
+    TCP pdu;
+    // it has a payload, it's just empty (unlike EOL/NOP options which have no payload)
+    pdu.add_option(TCP::option(TCP::SCPS_CAPABILITIES, 2));
+    EXPECT_EQ(1U, pdu.options().size());
+    EXPECT_EQ(pdu.serialize().size(), pdu.size());
+}
+
 TEST_F(TCPTest, MalformedOptionAfterEOL) {
     TCP tcp(malformed_option_after_eol_packet, sizeof(malformed_option_after_eol_packet));
     EXPECT_EQ(0U, tcp.options().size());


### PR DESCRIPTION
From https://www.iana.org/assignments/tcp-parameters/tcp-parameters.xhtml :

    > Options 0 and 1 are exactly one octet which is their kind field.  All
    > other options have their one octet kind field, followed by a one octet
    > length field, followed by length-2 octets of option data.

Options affected by the libtins bug are those where length is listed as:

* 2, except for SACK permitted, for which tins has an explicit workaround, or
* N, for packets where the options payload happens to be empty (N==2)

Without this fix, any affected packet can still be parsed, but trying
to serialize the resulting PDU object again will fail in
Tins::PDU::serialize -> Tins::TCP::write_serialization
-> Tins::Memory::OutputMemoryStream::fill.



I'm attaching a PCAP with an affected packet. This packet is from a real world product. I mention this because Wireshark says "Illegal SCPS Extended Capabilities (2 bytes)". Wireshark still gets the length right, and what's "wrong" (but real) about the packet isn't relevant here (for the curious... SCPS extended capability opts (extended means length!=4) "must" be preceded by a normal SCPS capability opt (normal means length==4). CCSDS 714.0-B-2 section 3.2.5.2.1, available on the Internet Archive. Disclaimer: I'm not a SCPS expert.). But none of that weirdness is related to this libtins bug, and anyway the libtins bug is not specific to SCPS.

[tcp ack with scps option without data.zip](https://github.com/mfontanini/libtins/files/4888129/tcp.ack.with.scps.option.without.data.zip)

(Unrelated note: I'd rather not even deal with the TCP layer and decode the IP payload, whatever that may be, as RawPDU, both for performance as well as the guarantee that *any* TCP/UDP/... and above headers will come out of tins unmodified, but it seems there's no good way to make libtins do that.)