### PR TITLE
Fix infinite loop when querying BSD routing table

### DIFF
--- a/src/utils/routing_utils.cpp
+++ b/src/utils/routing_utils.cpp
@@ -154,6 +154,7 @@ vector<char> query_route_table(int family) {
         throw exception_base("sysctl failed");
     }
 
+    buf.resize(len);
     return buf;
 }
 


### PR DESCRIPTION
Fix `query_route_table()` returning a buffer padded with extra '\0' bytes because it ignored the buffer size returned by `sysctl()`.

This caused `route_entries()` / `route6_entries()` to fall into an infinite loop, forever trying to parse a 0-length routing entry.