### PR TITLE
Fix wrong address endian

### DIFF
--- a/include/tins/icmp.h
+++ b/include/tins/icmp.h
@@ -320,7 +320,7 @@ public:
      * \return Returns the gateway field value.
      */
     address_type gateway() const {
-        return address_type(Endian::be_to_host(header_.un.gateway));
+        return address_type(header_.un.gateway);
     }
 
     /**
@@ -383,7 +383,7 @@ public:
       * \return Returns the address mask value.
       */
     address_type address_mask() const {
-        return address_type(Endian::be_to_host(orig_timestamp_or_address_mask_));
+        return address_type(orig_timestamp_or_address_mask_);
     }
 
     /**

--- a/src/icmp.cpp
+++ b/src/icmp.cpp
@@ -98,7 +98,7 @@ void ICMP::sequence(uint16_t new_seq) {
 }
 
 void ICMP::gateway(address_type new_gw) {
-    header_.un.gateway = Endian::host_to_be(static_cast<uint32_t>(new_gw));
+    header_.un.gateway = static_cast<uint32_t>(new_gw);
 }
 
 void ICMP::mtu(uint16_t new_mtu) {
@@ -122,7 +122,7 @@ void ICMP::transmit_timestamp(uint32_t new_timestamp) {
 }
 
 void ICMP::address_mask(address_type new_mask) {
-    orig_timestamp_or_address_mask_ = Endian::host_to_be(static_cast<uint32_t>(new_mask));
+    orig_timestamp_or_address_mask_ = static_cast<uint32_t>(new_mask);
 }
 
 uint32_t ICMP::header_size() const {


### PR DESCRIPTION
Host endian has been implicitly converted to big endian in "IPv4Address::operator uint32_t()"