### PR TITLE
IPv6 use interface when sending to link-local dest

### DIFF
--- a/include/tins/packet_sender.h
+++ b/include/tins/packet_sender.h
@@ -65,7 +65,9 @@ class PDU;
  * - Those that don't contain a link layer PDU. In this case, the 
  * kernel will be responsible for picking the appropriate network interface
  * based on the destination address.
- *
+ *  - Exception: <a href="https://datatracker.ietf.org/doc/html/rfc2553#section-3.3">RFC2553</a> 
+ * requires IPv6 link-scope address have a interface defined.
+ *  .
  * \par Note for Windows users:
  * Sending layer 3 PDUs (without a link layer protocol) is very restricted
  * on Windows (<a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms740548(v=vs.85).aspx">link</a>).


### PR DESCRIPTION
Attempting to send a `Tins::IPv6` PDU with a link-scope destination address will result in a "Network is unreachable" error (error code 101).
From the RFC2553 document section 3.3, it states

> The sin6_scope_id field is a 32-bit integer that identifies a set of interfaces
> as appropriate for the scope of the address carried in the sin6_addr field. 
> For a link scope sin6_addr, sin6_scope_id would be an interface index.

It understand this might be argued against since we're allowing a non-link layer PDU to be sent through a specified interface, but overall I think this should be up to the user to decide if a packet should be sent through a specified interface or allow the kernel to do so. Maybe that will be another pull request.