### PR TITLE
Fix conflict between variable and macro name

### DIFF
--- a/src/ipv6.cpp
+++ b/src/ipv6.cpp
@@ -32,6 +32,9 @@
     #include <netinet/in.h>
     #include <sys/socket.h>
 #else
+    #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+    #endif
     #include <ws2tcpip.h>
 #endif
 #include <tins/ipv6.h>


### PR DESCRIPTION
Fix conflict between variable and macro name when building on Msys2 / MinGW64.  
  
The errors that occurred are:  
```
libtins/src/ipv6.cpp:377:35: error: expected primary-expression before 'struct'
  377 |         link_addr.sin6_scope_id = interface.id();
      |                                   ^~~~~~~~~
ninja: build stopped: subcommand failed.
```

This change defines WIN32_LEAN_AND_MEAN and prevents interface macros from being defined.
