### PR TITLE
Fix a clang warning

### DIFF
--- a/include/tins/ip_reassembler.h
+++ b/include/tins/ip_reassembler.h
@@ -192,7 +192,6 @@ private:
     address_pair make_address_pair(IPv4Address addr1, IPv4Address addr2) const;
     
     streams_type streams_;
-    OverlappingTechnique technique_;
 };
 
 /**

--- a/src/ip_reassembler.cpp
+++ b/src/ip_reassembler.cpp
@@ -106,14 +106,7 @@ uint16_t IPv4Stream::extract_offset(const IP* ip) {
 
 } // Internals
 
-IPv4Reassembler::IPv4Reassembler()
-: technique_(NONE) {
-
-}
-
-IPv4Reassembler::IPv4Reassembler(OverlappingTechnique technique)
-: technique_(technique) {
-
+IPv4Reassembler::IPv4Reassembler() {
 }
 
 IPv4Reassembler::PacketStatus IPv4Reassembler::process(PDU& pdu) {


### PR DESCRIPTION
[  x%] Building CXX object src/CMakeFiles/tins.dir/ipsec.cpp.o
In file included from src/ip_reassembler.cpp:32:
src/../include/tins/ip_reassembler.h:195:26: warning: private field 'technique_' is not used [-Wunused-private-field]
    OverlappingTechnique technique_;
                         ^

Signed-off-by: Ferry Huberts <ferry.huberts@pelagic.nl>