### PR TITLE
Use CMAKE_INSTALL_LIBDIR in CONF_CMAKE_INSTALL_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ ENDIF()
 # **********************************
 
 if(UNIX)
-    set(CONF_CMAKE_INSTALL_DIR lib/cmake/libtins)
+    set(CONF_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/libtins")
 else()
     set(CONF_CMAKE_INSTALL_DIR CMake)
 endif()


### PR DESCRIPTION
On some platforms (like RedHat ones), CMAKE_INSTALL_LIBDIR is set to `lib64` instead of `lib`. The CMake files should also be installed to `lib64`, but because CONF_CMAKE_INSTALL_DIR is set unconditionally to use `lib`, the proper path can't be configured.

This change makes CONF_CMAKE_INSTALL_DIR use the configured CMAKE_INSTALL_LIBDIR value, which defaults to `lib`.

An alternative to this change would be to allow CONF_CMAKE_INSTALL_DIR to be specified manually rather than unconditionally setting it.