### PR TITLE
Add FileSniffer constructor with FILE pointer as pcap source

### DIFF
--- a/include/tins/sniffer.h
+++ b/include/tins/sniffer.h
@@ -408,8 +408,15 @@ class TINS_API FileSniffer : public BaseSniffer {
 public:
     /**
      * \brief Constructs an instance of FileSniffer.
+     * \param fp The pcap file which will be parsed.
+     * \param configuration A SnifferConfiguration to be used on the file.
+     */
+    FileSniffer(FILE *fp, const SnifferConfiguration& configuration);
+
+    /**
+     * \brief Constructs an instance of FileSniffer.
      * \param file_name The pcap file which will be parsed.
-     * \param filter A capture filter to be used on the file.(optional);
+     * \param configuration A SnifferConfiguration to be used on the file.
      */
     FileSniffer(const std::string& file_name, const SnifferConfiguration& configuration);
 
@@ -418,9 +425,18 @@ public:
      *
      * \brief Constructs an instance of FileSniffer.
      * \param file_name The pcap file which will be parsed.
-     * \param filter A capture filter to be used on the file.(optional);
+     * \param filter A capture filter to be used on the file. (optional)
      */
     FileSniffer(const std::string& file_name, const std::string& filter = "");
+
+    /**
+     * \deprecated Use the constructor that takes a SnifferConfiguration instead.
+     *
+     * \brief Constructs an instance of FileSniffer.
+     * \param fp The pcap file which will be parsed.
+     * \param filter A capture filter to be used on the file. (optional)
+     */
+    FileSniffer(FILE *fp, const std::string& filter = "");
 };
 
 template <typename T>

--- a/src/sniffer.cpp
+++ b/src/sniffer.cpp
@@ -391,6 +391,20 @@ void Sniffer::set_rfmon(bool rfmon_enabled) {
 
 // **************************** FileSniffer ****************************
 
+FileSniffer::FileSniffer(FILE *fp,
+                         const SnifferConfiguration& configuration) {
+    char error[PCAP_ERRBUF_SIZE];
+    pcap_t* phandle = pcap_fopen_offline(fp, error);
+    if (!phandle) {
+        throw pcap_error(error);
+    }
+    set_pcap_handle(phandle);
+
+    // Configure the sniffer
+    configuration.configure_sniffer_pre_activation(*this);
+
+}
+
 FileSniffer::FileSniffer(const string& file_name, 
                          const SnifferConfiguration& configuration) {
     char error[PCAP_ERRBUF_SIZE];
@@ -419,6 +433,22 @@ FileSniffer::FileSniffer(const string& file_name, const string& filter) {
     // Configure the sniffer
     config.configure_sniffer_pre_activation(*this);
 }
+
+FileSniffer::FileSniffer(FILE *fp, const string& filter) {
+    SnifferConfiguration config;
+    config.set_filter(filter);
+
+    char error[PCAP_ERRBUF_SIZE];
+    pcap_t* phandle = pcap_fopen_offline(fp, error);
+    if (!phandle) {
+        throw pcap_error(error);
+    }
+    set_pcap_handle(phandle);
+
+    // Configure the sniffer
+    config.configure_sniffer_pre_activation(*this);
+}
+
 
 // ************************ SnifferConfiguration ************************
 


### PR DESCRIPTION
This PR adds two overloads for the `FileSniffer` class:

```c++
FileSniffer(FILE *fp, const SnifferConfiguration& configuration);
FileSniffer(FILE *fp, const std::string& filter = "");
```

The possibility of opening a pcap by providing a FILE pointer adds more flexibility, e.g. for working with pipes.