### PR TITLE
Ignore IPv6 packets with payload after one with no Next Header

### DIFF
--- a/src/ipv6.cpp
+++ b/src/ipv6.cpp
@@ -130,7 +130,7 @@ IPv6::IPv6(const uint8_t* buffer, uint32_t total_sz) {
     uint32_t actual_payload_length = payload_length();
     bool is_payload_fragmented = false;
     while (stream) {
-        if (is_extension_header(current_header)) {
+        if (is_extension_header(current_header) && current_header != NO_NEXT_HEADER) {
             if (current_header == FRAGMENT) {
                 is_payload_fragmented = true;
             }


### PR DESCRIPTION
IPv6 data packets with payload or padded bytes received after one with no Next Header were not being parsed correctly, resulting in NULL PDU.

This commit fixes the IPv6 parser to be compliant with RFC 2460 Section 4.7 by adding a check in the IPv6 constructor to ignore the subsequent packets if an IPv6 packet contains no Next Header.

Signed-off-by: James Raphael Tiovalen <jamestiotio@gmail.com>