### PR TITLE
Add vxlan.h to CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -152,6 +152,7 @@ set(HEADERS
     ${LIBTINS_INCLUDE_DIR}/tins/utils/routing_utils.h
     ${LIBTINS_INCLUDE_DIR}/tins/utils/resolve_utils.h
     ${LIBTINS_INCLUDE_DIR}/tins/utils/pdu_utils.h
+    ${LIBTINS_INCLUDE_DIR}/tins/vxlan.h
 )
 
 SET(DOT11_DEPENDENT_SOURCES


### PR DESCRIPTION
With this change, running `make install` should now install the `vxlan.h` header file.

Thanks to @paulie-g for mentioning about this [here](https://github.com/mfontanini/libtins/commit/850bb9b642a2f842808c53e83b275204777cae7f#commitcomment-115766657). It seems that I forgot to add the header file. 😅