### PR TITLE
[CMake] Also include ntdll.lib on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ ENDIF()
 # Set some Windows specific flags
 IF(WIN32)
     # We need to link against these libs
-    SET(LIBTINS_OS_LIBS Ws2_32.lib Iphlpapi.lib)
+    SET(LIBTINS_OS_LIBS Ws2_32.lib Iphlpapi.lib ntdll.lib)
 
     # Add the NOMINMAX macro to avoid Windows' min and max macros.
     ADD_DEFINITIONS(-DNOMINMAX)


### PR DESCRIPTION
This should fix the error: Undefined reference to RtlIpv6AddressToStringExA.

I was trying to compile on mingw64-x86_64 and getting this error, turns out this symbol is exported by the ntdll library