### PR TITLE
Resolves #525 Android 24+ support

### DIFF
--- a/src/network_interface.cpp
+++ b/src/network_interface.cpp
@@ -331,7 +331,7 @@ NetworkInterface::Info NetworkInterface::info() const {
     }
 
     #else // _WIN32
-    #ifndef ANDROID 
+    #if !defined(ANDROID) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 24)
     struct ifaddrs* ifaddrs = 0;
     struct ifaddrs* if_it = 0;
     getifaddrs(&ifaddrs);

--- a/src/utils/routing_utils.cpp
+++ b/src/utils/routing_utils.cpp
@@ -413,7 +413,7 @@ set<string> network_interfaces() {
 }
 #else
 set<string> network_interfaces() {
-    #ifndef ANDROID 
+    #if !defined(ANDROID) || (defined(__ANDROID_API__) && __ANDROID_API__ >= 24)
         set<string> output;
         struct ifaddrs* ifaddrs = 0;
         struct ifaddrs* if_it = 0;


### PR DESCRIPTION
Update to allow calls to `getifaddrs()` and `freeifaddrs` on Android systems with API Level 24+

Support in Android: https://android.googlesource.com/platform/bionic/+/master/libc/include/ifaddrs.h
