### PR TITLE
Don't throw exception for empty interface

### DIFF
--- a/src/network_interface.cpp
+++ b/src/network_interface.cpp
@@ -347,9 +347,11 @@ NetworkInterface::Info NetworkInterface::info() const {
     #endif // _WIN32
     
      // If we didn't even get the hw address or ip address, this went wrong
-    if (!collector.found_hw && !collector.found_ip) {
-        throw invalid_interface();
-    }
+    // Should this really return an exception?
+    // On Openwrt device with netem, an empty interface is created for sch_teql
+    // if (!collector.found_hw && !collector.found_ip) {
+    //     throw invalid_interface();
+    // }
 
     return info;
 }


### PR DESCRIPTION
had an odd issue on my openwrt router. my libtins app would worked fine until installing `netem` e.g. `opkg install kmod-netem` which depends on `kmod-sched`. After installing that, a new empty interface is created (at least on openwrt, not sure about other distros) that has no IP address.

I see no reason to throw an exception here. It is especially problematic because at least in my app, the interfaces are initialized when the program starts, I suppose in a constructor somewhere.

Simply removing this solves the issue. Perhaps a better approach would be to only throw an exception when a given interface is empty and chosen for us with a sniffer. I'm not exactly sure how `kmod-sched` uses the empty interface, but it may even be desirable to monitor such an interface.

In short.. I believe this check should be deleted or at least turned into something that doesnt abort a program.