### PR TITLE
fixed std::uint32_t

### DIFF
--- a/include/tins/ip_address.h
+++ b/include/tins/ip_address.h
@@ -262,7 +262,7 @@ template<>
 struct hash<Tins::IPv4Address> {
     size_t operator()(const Tins::IPv4Address& addr) const
     {
-        return std::hash<std::uint32_t>()(addr);
+        return std::hash<uint32_t>()(addr);
     }
 };
 


### PR DESCRIPTION
std::uint32_t no longer exists in newer gcc versions, it should be changed to the normal uint32_t 
i've also made an issue for this pull request: https://github.com/mfontanini/libtins/issues/542