### PR TITLE
Update Channel Switch Timing to 104 in enum as 103 is reserved

### DIFF
--- a/include/tins/dot11/dot11_base.h
+++ b/include/tins/dot11/dot11_base.h
@@ -182,7 +182,7 @@ public:
         DMS_RESP,
         LINK_ID,
         WAKEUP_SCHEDULE,
-        CH_SWITCH_TIMING,
+        CH_SWITCH_TIMING = 104,
         PTI_CONTROL,
         TPU_BUFFER_STATUS,
         INTERWORKING,


### PR DESCRIPTION
The "Channel Switch Timing" Element ID should be 104 because 103 is reserved according to 802.11-2024 (page 925). This causes all IEs after "Wakeup Schedule" (102) to be incorrect.